### PR TITLE
fix(jobhunt): enumerate valid application-status values (closes #2)

### DIFF
--- a/skills/demo/jobhunt/jobhunt.py
+++ b/skills/demo/jobhunt/jobhunt.py
@@ -192,6 +192,12 @@ def format_size(size_bytes):
 CACHE_AVAILABLE = True
 
 
+# Valid values for application-status (drives pipeline filtering — must be exact lowercase match)
+ALLOWED_APPLICATION_STATUSES = {
+    "researching", "applied", "phone-screen",
+    "interviewing", "offer", "rejected", "withdrawn",
+}
+
 # Configuration
 TYPEDB_HOST = os.getenv("TYPEDB_HOST", "localhost")
 TYPEDB_PORT = int(os.getenv("TYPEDB_PORT", "1729"))
@@ -549,6 +555,15 @@ def cmd_add_position(args):
 
 def cmd_update_status(args):
     """Update application status for a position."""
+    if args.status not in ALLOWED_APPLICATION_STATUSES:
+        print(
+            f"Error: invalid status '{args.status}'. "
+            f"Valid values: {', '.join(sorted(ALLOWED_APPLICATION_STATUSES))}",
+            file=sys.stderr,
+        )
+        print(json.dumps({"success": False, "error": f"invalid status: {args.status}"}))
+        return
+
     timestamp = get_timestamp()
     note_id = generate_id("note")
 

--- a/skills/demo/jobhunt/schema.tql
+++ b/skills/demo/jobhunt/schema.tql
@@ -26,6 +26,7 @@ attribute remote-policy, value string;
 attribute team-size, value string;
 
 # Application tracking
+# Valid application-status values: researching | applied | phone-screen | interviewing | offer | rejected | withdrawn
 attribute application-status, value string;
 attribute applied-date, value datetime;
 attribute interview-date, value datetime;


### PR DESCRIPTION
Closes #2

## Changes

**`skills/demo/jobhunt/schema.tql`**
- Added valid-value comment on `application-status`: `researching | applied | phone-screen | interviewing | offer | rejected | withdrawn`

**`skills/demo/jobhunt/jobhunt.py`**
- Added `ALLOWED_APPLICATION_STATUSES` constant (frozen set of 7 valid values)
- Added pre-insert validation in `cmd_update_status` — returns a clear error with the valid value list instead of silently inserting a bad string

## Why

Pipeline queries filter by `application-status` string equality. A case mismatch or synonym drift (`"Researching"` vs `"researching"`, `"submitted"` vs `"applied"`) would silently return zero records with no error at insert time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)