### PR TITLE
Repoint alhazen-core to the skillful-alhazen marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # alhazen-skill-examples
 
-Example skills for the [Skillful Alhazen](https://github.com/GullyBurns/skillful-alhazen) knowledge notebook framework — a TypeDB-powered scientific notebook for researchers building knowledge graphs from papers, notes, and domain data.
+Example skills for the [Skillful Alhazen](https://github.com/sciknow-io/skillful-alhazen) knowledge notebook framework — a TypeDB-powered scientific notebook for researchers building knowledge graphs from papers, notes, and domain data.
 
 ## What is this?
 
@@ -68,10 +68,10 @@ uv run --project <skill-path> python <skill-path>/jobhunt.py list-pipeline
 
 Standard plugins depend on the `alhazen-core` infrastructure plugin. Install it first, then install domain skills individually.
 
-**Step 1 — Add the marketplace and install alhazen-core:**
+**Step 1 — Install the `alhazen-core` infrastructure plugin (from the skillful-alhazen marketplace):**
 ```
-/plugin marketplace add sciknow-io/alhazen-skill-examples
-/plugin install alhazen-core@alhazen-skills
+/plugin marketplace add sciknow-io/skillful-alhazen
+/plugin install alhazen-core@skillful-alhazen
 ```
 
 Initialize the infrastructure (one-time):
@@ -90,7 +90,13 @@ Expected output:
 }
 ```
 
-**Step 2 — Use a domain skill:**
+**Step 2 — Add this marketplace and install a domain skill:**
+```
+/plugin marketplace add sciknow-io/alhazen-skill-examples
+/plugin install they-said-whaaa@alhazen-skills
+```
+
+Then use it:
 ```bash
 # Replace <skill-path> with your plugin cache path
 # e.g. ~/.claude/plugins/cache/they-said-whaaa/
@@ -308,7 +314,7 @@ demo/                       # Shared Next.js base app
 
 ## Building a New Skill
 
-See the [Alhazen Skill Architecture](https://github.com/GullyBurns/skillful-alhazen/wiki/Skill-Architecture) wiki for a full guide.
+See the [Alhazen Skill Architecture](https://github.com/sciknow-io/skillful-alhazen/wiki/Skill-Architecture) wiki for a full guide.
 
 **Standard skill** (depends on alhazen-core):
 

--- a/demo/src/app/page.tsx
+++ b/demo/src/app/page.tsx
@@ -43,7 +43,7 @@ export default function HubPage() {
             assembled into this app via <code className="font-mono">make demo-sync</code>.
             See the{" "}
             <a
-              href="https://github.com/GullyBurns/alhazen-skill-examples"
+              href="https://github.com/sciknow-io/alhazen-skill-examples"
               className="text-primary underline underline-offset-2 hover:text-primary/80"
             >
               README

--- a/skills/biomed/alg-precision-therapeutics/hooks/hooks.json
+++ b/skills/biomed/alg-precision-therapeutics/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "CORE=$(find ~/.claude/plugins/cache -path '*/alhazen-core/*/alhazen_core.py' 2>/dev/null | head -1); if [ -z \"$CORE\" ]; then echo \"alhazen-core plugin required. Run: /plugin install alhazen-core@alhazen-core\" && exit 1; fi; CORE_DIR=$(dirname \"$CORE\"); uv run --project \"$CORE_DIR\" python \"$CORE\" init && uv run --project \"$CORE_DIR\" python \"$CORE\" load-schema \"${CLAUDE_PLUGIN_ROOT}/schema.tql\"",
+            "command": "CORE=$(find ~/.claude/plugins/cache -path '*/alhazen-core/*/alhazen_core.py' 2>/dev/null | head -1); if [ -z \"$CORE\" ]; then echo \"alhazen-core plugin required. Run: /plugin install alhazen-core@skillful-alhazen\" && exit 1; fi; CORE_DIR=$(dirname \"$CORE\"); uv run --project \"$CORE_DIR\" python \"$CORE\" init && uv run --project \"$CORE_DIR\" python \"$CORE\" load-schema \"${CLAUDE_PLUGIN_ROOT}/schema.tql\"",
             "timeout": 90000
           }
         ]

--- a/skills/biomed/literature-trends/hooks/hooks.json
+++ b/skills/biomed/literature-trends/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "CORE=$(find ~/.claude/plugins/cache -path '*/alhazen-core/*/alhazen_core.py' 2>/dev/null | head -1); if [ -z \"$CORE\" ]; then echo \"alhazen-core plugin required. Run: /plugin install alhazen-core@alhazen-core\" && exit 1; fi; CORE_DIR=$(dirname \"$CORE\"); uv run --project \"$CORE_DIR\" python \"$CORE\" init && uv run --project \"$CORE_DIR\" python \"$CORE\" load-schema \"${CLAUDE_PLUGIN_ROOT}/schema.tql\"",
+            "command": "CORE=$(find ~/.claude/plugins/cache -path '*/alhazen-core/*/alhazen_core.py' 2>/dev/null | head -1); if [ -z \"$CORE\" ]; then echo \"alhazen-core plugin required. Run: /plugin install alhazen-core@skillful-alhazen\" && exit 1; fi; CORE_DIR=$(dirname \"$CORE\"); uv run --project \"$CORE_DIR\" python \"$CORE\" init && uv run --project \"$CORE_DIR\" python \"$CORE\" load-schema \"${CLAUDE_PLUGIN_ROOT}/schema.tql\"",
             "timeout": 90000
           }
         ]

--- a/skills/biomed/scientific-literature/hooks/hooks.json
+++ b/skills/biomed/scientific-literature/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "CORE=$(find ~/.claude/plugins/cache -path '*/alhazen-core/*/alhazen_core.py' 2>/dev/null | head -1); if [ -z \"$CORE\" ]; then echo \"alhazen-core plugin required. Run: /plugin install alhazen-core@alhazen-core\" && exit 1; fi; CORE_DIR=$(dirname \"$CORE\"); uv run --project \"$CORE_DIR\" python \"$CORE\" init && uv run --project \"$CORE_DIR\" python \"$CORE\" load-schema \"${CLAUDE_PLUGIN_ROOT}/schema.tql\"",
+            "command": "CORE=$(find ~/.claude/plugins/cache -path '*/alhazen-core/*/alhazen_core.py' 2>/dev/null | head -1); if [ -z \"$CORE\" ]; then echo \"alhazen-core plugin required. Run: /plugin install alhazen-core@skillful-alhazen\" && exit 1; fi; CORE_DIR=$(dirname \"$CORE\"); uv run --project \"$CORE_DIR\" python \"$CORE\" init && uv run --project \"$CORE_DIR\" python \"$CORE\" load-schema \"${CLAUDE_PLUGIN_ROOT}/schema.tql\"",
             "timeout": 90000
           }
         ]

--- a/skills/demo/jobhunt/hooks/hooks.json
+++ b/skills/demo/jobhunt/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "CORE=$(find ~/.claude/plugins/cache -path '*/alhazen-core/*/alhazen_core.py' 2>/dev/null | head -1); if [ -z \"$CORE\" ]; then echo \"alhazen-core plugin required. Run: /plugin install alhazen-core@alhazen-core\" && exit 1; fi; CORE_DIR=$(dirname \"$CORE\"); uv run --project \"$CORE_DIR\" python \"$CORE\" init && uv run --project \"$CORE_DIR\" python \"$CORE\" load-schema \"${CLAUDE_PLUGIN_ROOT}/schema.tql\"",
+            "command": "CORE=$(find ~/.claude/plugins/cache -path '*/alhazen-core/*/alhazen_core.py' 2>/dev/null | head -1); if [ -z \"$CORE\" ]; then echo \"alhazen-core plugin required. Run: /plugin install alhazen-core@skillful-alhazen\" && exit 1; fi; CORE_DIR=$(dirname \"$CORE\"); uv run --project \"$CORE_DIR\" python \"$CORE\" init && uv run --project \"$CORE_DIR\" python \"$CORE\" load-schema \"${CLAUDE_PLUGIN_ROOT}/schema.tql\"",
             "timeout": 90000
           }
         ]

--- a/skills/health/coach/hooks/hooks.json
+++ b/skills/health/coach/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "CORE=$(find ~/.claude/plugins/cache -path '*/alhazen-core/*/alhazen_core.py' 2>/dev/null | head -1); if [ -z \"$CORE\" ]; then echo \"alhazen-core plugin required. Run: /plugin install alhazen-core@alhazen-core\" && exit 1; fi; CORE_DIR=$(dirname \"$CORE\"); uv run --project \"$CORE_DIR\" python \"$CORE\" init && uv run --project \"$CORE_DIR\" python \"$CORE\" load-schema \"${CLAUDE_PLUGIN_ROOT}/schema.tql\"",
+            "command": "CORE=$(find ~/.claude/plugins/cache -path '*/alhazen-core/*/alhazen_core.py' 2>/dev/null | head -1); if [ -z \"$CORE\" ]; then echo \"alhazen-core plugin required. Run: /plugin install alhazen-core@skillful-alhazen\" && exit 1; fi; CORE_DIR=$(dirname \"$CORE\"); uv run --project \"$CORE_DIR\" python \"$CORE\" init && uv run --project \"$CORE_DIR\" python \"$CORE\" load-schema \"${CLAUDE_PLUGIN_ROOT}/schema.tql\"",
             "timeout": 90000
           }
         ]

--- a/skills/journalism/they-said-whaaa/hooks/hooks.json
+++ b/skills/journalism/they-said-whaaa/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "CORE=$(find ~/.claude/plugins/cache -path '*/alhazen-core/*/alhazen_core.py' 2>/dev/null | head -1); if [ -z \"$CORE\" ]; then echo \"alhazen-core plugin required. Run: /plugin install alhazen-core@alhazen-core\" && exit 1; fi; CORE_DIR=$(dirname \"$CORE\"); uv run --project \"$CORE_DIR\" python \"$CORE\" init && uv run --project \"$CORE_DIR\" python \"$CORE\" load-schema \"${CLAUDE_PLUGIN_ROOT}/schema.tql\"",
+            "command": "CORE=$(find ~/.claude/plugins/cache -path '*/alhazen-core/*/alhazen_core.py' 2>/dev/null | head -1); if [ -z \"$CORE\" ]; then echo \"alhazen-core plugin required. Run: /plugin install alhazen-core@skillful-alhazen\" && exit 1; fi; CORE_DIR=$(dirname \"$CORE\"); uv run --project \"$CORE_DIR\" python \"$CORE\" init && uv run --project \"$CORE_DIR\" python \"$CORE\" load-schema \"${CLAUDE_PLUGIN_ROOT}/schema.tql\"",
             "timeout": 90000
           }
         ]


### PR DESCRIPTION
## Summary
`alhazen-core` was moved out of this marketplace into **sciknow-io/skillful-alhazen**, where it now ships the compose-based setup (TypeDB + dashboard + persistent `typedb-data` volume) instead of a bare `docker run`. The plugins here still pointed users at the old install path, which is broken. This repoints everything:

- **README "Standard plugins" flow** — Step 1 installs `alhazen-core@skillful-alhazen` from `sciknow-io/skillful-alhazen`; Step 2 adds *this* marketplace for the domain skills.
- **6 plugin SessionStart hooks** (jobhunt, coach, scientific-literature, literature-trends, alg-precision-therapeutics, they-said-whaaa) — the "alhazen-core required" hint now reads `/plugin install alhazen-core@skillful-alhazen` (was the old `@alhazen-core` marketplace name).
- **Stale repo links** — `GullyBurns/*` -> `sciknow-io/*` (repos were transferred).

## Notes
- The marketplace-agnostic `find ~/.claude/plugins/cache -path '*/alhazen-core/*/alhazen_core.py'` lookup in the hooks is unchanged — only the user-facing install hint.
- `alhazen-core` is already de-listed from this repo's `marketplace.json`; no change needed there.

## Test plan
- [ ] `/plugin marketplace add sciknow-io/skillful-alhazen` + `/plugin install alhazen-core@skillful-alhazen` + `/alhazen-core:init` brings up TypeDB + dashboard.
- [ ] `/plugin marketplace add sciknow-io/alhazen-skill-examples` + install a domain skill; its SessionStart hook finds alhazen-core and initializes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)