### PR TITLE
scilit: deterministic paper identity + unified per-paper full-text scheme

### DIFF
--- a/skills/biomed/scientific-literature/SKILL.md
+++ b/skills/biomed/scientific-literature/SKILL.md
@@ -55,5 +55,62 @@ uv run --project <skill-path> python <skill-path>/scientific_literature.py list 
     --collection "collection-abc123"
 ```
 
+## Full-Text Ingestion & Per-Paper Cache — REQUIRED convention
+
+This is the ONLY correct way to ingest a paper's full text and cache its files. It is
+**mandatory and uniform across every scilit investigation** (search corpora, deep-dives,
+CAIS, etc.) — never improvise an alternate layout.
+
+### 1. Paper identity (deterministic)
+Every paper is a `scilit-paper` whose id is a **pure function of its best stable
+identifier**: `DOI → PMID → arXiv → content-hash(title|first-author|year)`. Compute it
+with `paper_identity()` in `paper_identity.py`; create/find papers only via
+`kqed.upsert_paper(driver, meta)`. Same paper → same id, always. The tier is recorded in
+`scilit-identity-basis` / `scilit-identity-value`. (Full design: `docs/paper-identity-design.md`.)
+
+### 2. One directory per paper holds ALL of its content
+```
+~/.alhazen/cache/fulltext/<paper-id>/
+    source.pdf                  # the source PDF
+    text.md                     # full text extracted by kreuzberg
+    tables/<n>.md               # kreuzberg-extracted tables
+    figures/<n>.png             # extracted figures
+    supplement/<original-name>  # supplementary files
+    data/<original-name>        # associated datasets / data files
+```
+**EVERY file derived from, or supplied with, a specific paper goes in that paper's
+`fulltext/<paper-id>/` subdirectory — and nowhere else.** This explicitly includes
+kreuzberg text/table extraction (do NOT leave it in `cache/extracted/` or `cache/text/`),
+the source PDF (NOT `cache/pdf/` or `cache/papers/`), and all supplemental / data files.
+
+### 3. Rules
+- **MOVE files into place** (copy, then remove the original) — **never symlink**, and never
+  leave a paper's content scattered in `cache/pdf/`, `cache/text/`, `cache/extracted/`, or
+  `cache/papers/`.
+- **Register every cached file** as an `alh-artifact` with id
+  `scilit-fulltext-<paper-hash>-<kind>` (paper-hash = the paper id's 12-hex suffix), attribute
+  `scilit-fulltext-kind` ∈ `pdf | text | table | figure | supplement | data`, and
+  `cache-path = fulltext/<paper-id>/<file>`, linked to the paper via `alh-representation`.
+- **The path is computable from the paper id** — `paper → fulltext/<paper-id>/source.pdf`
+  needs no graph lookup. Keep it that way.
+- A paper with a local source PDF must carry `scilit-acquisition-status = held`; a
+  cited-but-undownloaded reference is `needed`.
+
+### 4. Ingestion flow (per paper)
+1. `upsert_paper(meta)` → deterministic `<paper-id>`.
+2. Download the source PDF → **move** to `fulltext/<paper-id>/source.pdf`; register the `pdf` artifact; set status `held`.
+3. Extract text/tables with kreuzberg → write `text.md`, `tables/*` **into the same dir**; register `text`/`table` artifacts.
+4. Any figures / supplemental / data files → same dir, registered with the matching `kind`.
+5. Never write any of the above outside `fulltext/<paper-id>/`.
+
+> `cache/pdf/` may still hold OTHER skills' documents (tech-recon, health-coach) — those are
+> out of scope for this convention; do not touch them. This convention governs `scilit-paper`
+> content only.
+
+Reconciliation prototypes that retrofit existing data to this layout live in
+`prototypes/reconcile_*_fulltext.py` (they MOVE sources into `fulltext/<paper-id>/`).
+
+---
+
 **Read USAGE.md before executing commands** -- full command reference, source-specific options,
 query syntax, semantic search workflow, and clustering guide.

--- a/skills/biomed/scientific-literature/SKILL.md
+++ b/skills/biomed/scientific-literature/SKILL.md
@@ -68,39 +68,43 @@ with `paper_identity()` in `paper_identity.py`; create/find papers only via
 `kqed.upsert_paper(driver, meta)`. Same paper → same id, always. The tier is recorded in
 `scilit-identity-basis` / `scilit-identity-value`. (Full design: `docs/paper-identity-design.md`.)
 
-### 2. One directory per paper holds ALL of its content
+### 2. One directory per paper; every file is named by ITS artifact id
 ```
 ~/.alhazen/cache/fulltext/<paper-id>/
-    source.pdf                  # the source PDF
-    text.md                     # full text extracted by kreuzberg
-    tables/<n>.md               # kreuzberg-extracted tables
-    figures/<n>.png             # extracted figures
-    supplement/<original-name>  # supplementary files
-    data/<original-name>        # associated datasets / data files
+    scilit-fulltext-<paper-hash>.pdf   # source rendition  ┐ ONE full-text artifact
+    scilit-fulltext-<paper-hash>.txt   # kreuzberg text     ┘ (renditions share the id-base)
+    <other-artifact-id>.<ext>          # any OTHER artifact of the paper (table/figure/supplement/data)
 ```
-**EVERY file derived from, or supplied with, a specific paper goes in that paper's
-`fulltext/<paper-id>/` subdirectory — and nowhere else.** This explicitly includes
-kreuzberg text/table extraction (do NOT leave it in `cache/extracted/` or `cache/text/`),
-the source PDF (NOT `cache/pdf/` or `cache/papers/`), and all supplemental / data files.
+**A paper may have several artifacts; each FILE is named by the id of the artifact it
+belongs to (basename = artifact id, suffix = format).** There is ONE **full-text artifact**
+per paper, `scilit-fulltext-<paper-hash>` (paper-hash = the paper id's 12-hex suffix); its
+`.pdf` source and `.txt` extraction are two **renditions of that single artifact**, sharing
+the id-base and differing only by suffix. Any other content (extracted tables, figures,
+supplements, datasets) is its OWN `alh-artifact`, file `<that-artifact-id>.<ext>`.
+**EVERY such file goes in that paper's `fulltext/<paper-id>/` subdirectory — and nowhere
+else** (NOT `cache/pdf/`, `cache/text/`, `cache/extracted/`, or `cache/papers/`).
 
 ### 3. Rules
 - **MOVE files into place** (copy, then remove the original) — **never symlink**, and never
   leave a paper's content scattered in `cache/pdf/`, `cache/text/`, `cache/extracted/`, or
   `cache/papers/`.
-- **Register every cached file** as an `alh-artifact` with id
-  `scilit-fulltext-<paper-hash>-<kind>` (paper-hash = the paper id's 12-hex suffix), attribute
-  `scilit-fulltext-kind` ∈ `pdf | text | table | figure | supplement | data`, and
-  `cache-path = fulltext/<paper-id>/<file>`, linked to the paper via `alh-representation`.
-- **The path is computable from the paper id** — `paper → fulltext/<paper-id>/source.pdf`
+- The **filename basename equals the artifact id** — a loose file is self-identifying.
+- **Register every file as an `alh-artifact` with a complete file xref:**
+  `cache-path = fulltext/<paper-id>/<artifact-id>.<ext>` **plus** `content-hash` (sha256),
+  `file-size`, `mime-type`, and `format` — linked to the paper via `alh-representation`.
+  The full-text artifact's `cache-path` points at its text rendition (`.txt`, the indexable
+  one); the `.pdf` is the sibling by suffix.
+- **The path is computable from the paper id** — the full-text artifact id is deterministic
+  (`scilit-fulltext-<paper-hash>`), so `paper → fulltext/<paper-id>/scilit-fulltext-<paper-hash>.pdf`
   needs no graph lookup. Keep it that way.
 - A paper with a local source PDF must carry `scilit-acquisition-status = held`; a
   cited-but-undownloaded reference is `needed`.
 
 ### 4. Ingestion flow (per paper)
-1. `upsert_paper(meta)` → deterministic `<paper-id>`.
-2. Download the source PDF → **move** to `fulltext/<paper-id>/source.pdf`; register the `pdf` artifact; set status `held`.
-3. Extract text/tables with kreuzberg → write `text.md`, `tables/*` **into the same dir**; register `text`/`table` artifacts.
-4. Any figures / supplemental / data files → same dir, registered with the matching `kind`.
+1. `upsert_paper(meta)` → deterministic `<paper-id>`; full-text artifact id `scilit-fulltext-<paper-hash>`.
+2. Download the source PDF → **move** to `fulltext/<paper-id>/scilit-fulltext-<paper-hash>.pdf`; register the artifact with the complete file xref (cache-path + content-hash + file-size + mime-type + format); set status `held`.
+3. kreuzberg-extract the text → write `fulltext/<paper-id>/scilit-fulltext-<paper-hash>.txt` as the **same** artifact's `.txt` rendition.
+4. Extracted tables / figures / supplements / data → each its OWN artifact, file `<artifact-id>.<ext>` in the same dir, with its own complete file xref.
 5. Never write any of the above outside `fulltext/<paper-id>/`.
 
 > `cache/pdf/` may still hold OTHER skills' documents (tech-recon, health-coach) — those are

--- a/skills/biomed/scientific-literature/USAGE.md
+++ b/skills/biomed/scientific-literature/USAGE.md
@@ -651,6 +651,25 @@ uv run python .claude/skills/scientific-literature/scientific_literature.py expo
 
 ---
 
+## Meeting surveys (discourse sources)
+
+A **meeting survey** (a `survey`-type investigation, e.g. the CAIS 2026 conference survey)
+covers a program of papers + spoken sessions. Two types support this, both in the
+**domain-neutral discourse/source layer** (KQED System 1) — they never touch the biomed
+S2/S3 (KEfED, bio-mechanism):
+
+- **`scilit-session`** — a discourse SOURCE (keynote | workshop | tutorial | talk | panel),
+  sibling of `scilit-paper`. Owns `scilit-session-type`, `scilit-speaker` (multi),
+  `scilit-affiliation` (multi), `scilit-session-url`, `scilit-publication-year`. A claim can
+  cite a talk via `scilit-hinge:hinged-to`, exactly as it cites a paper; a session is a corpus
+  member and an aboutness subject like any source.
+- **`scilit-experience-note`** — a first-person anecdote / engagement record (`sub
+  alh-sensemaking-note`), `about` a session/paper/person. Owns `scilit-experience-event` (the
+  occasion, e.g. "CAIS 2026 keynote"). This is distinct from the KQED epistemic
+  `scilit-observation` (a measurement-in-context, System 2 / KEfED D-node).
+
+---
+
 ## Source Connector Details
 
 ### Europe PMC

--- a/skills/biomed/scientific-literature/docs/paper-identity-design.md
+++ b/skills/biomed/scientific-literature/docs/paper-identity-design.md
@@ -89,6 +89,14 @@ No code path calls `generate_id("scilit-paper")` any more. Dedup is enforced at 
 
 ## §5 — Full-text identity (extension)
 
+> **SUPERSEDED naming (2026-06-24):** the filename/id convention below (`source.pdf`/`text.md`,
+> per-`(paper,kind)` artifact id `scilit-fulltext-<paper-hash>-<kind>`) was later replaced by:
+> **one `scilit-fulltext-<paper-hash>` artifact per paper** whose renditions are named by the
+> artifact id — `fulltext/<paper-id>/scilit-fulltext-<paper-hash>.pdf` (and `.txt`), sharing the
+> id-base. Files are **moved** (not symlinked) and carry a complete file xref
+> (`cache-path` + `content-hash` + `file-size` + `mime-type`). See `SKILL.md` (the live convention)
+> and `prototypes/rename_fulltext_artifact_files.py`. The original text is kept for history.
+
 Full text stays an `alh-artifact` linked by `alh-representation` (`alh-artifact ↔ referent`), but gains **identity derived from the paper + a `kind`**:
 
 - **Kinds:** `pdf` (source PDF), `text` (extracted markdown). Extensible (`html`, `supplement`).

--- a/skills/biomed/scientific-literature/docs/paper-identity-design.md
+++ b/skills/biomed/scientific-literature/docs/paper-identity-design.md
@@ -1,0 +1,115 @@
+# Paper Identity Convention — Design Spec
+
+- **Date:** 2026-06-24
+- **Status:** Approved (design); pending implementation plan
+- **Scope:** `scilit-paper` identity + full-text artifact identity. **Out of scope:** the citation / reference-key *model* (`<citing>:<position>`).
+
+## Context & problem
+
+A `scilit-paper` is currently identified by an **opaque random-hex id** (`scilit-paper-<12hex>`, minted by `generate_id`). This is position-independent but **unstable**: re-ingesting the same paper mints a *new* id, so the same real paper can fragment into multiple records (we already have one duplicate-DOI collision, `10.1056/nejmoa1805819` → 2 papers).
+
+Separately, the `scilit-reference-key` attribute (`<citing-paper-id>:<ref-number>`, on 294 papers) **indexes on citation position**. That scheme caused a systematic mis-resolution bug (Crossref `bibNN` key ≠ in-text citation number), fixed in `prototypes/fix_citation_registry.py`. That experience motivates a paper identity that is **derived from the paper itself**, never from a citing context or position.
+
+Corpus facts (2026-06-24): 426 papers; 419 have a DOI (98%), 299 a PMID (70%), 294 a reference-key. The 7 DOI-less papers are hand-seeded `kqed-stub-N` mention stubs. 577 `alh-artifact`s exist but only **114 papers** have a graph-linked full-text artifact, while **412 PDFs** sit in `cache/pdf/` keyed by DOI.
+
+## Goals / non-goals
+
+**Goals**
+- A paper's TypeDB id is its **canonical identity**, computed **deterministically** so the same paper always maps to the same id (dedup by construction).
+- The convention is **general**: every paper gets an id, including DOI-less ones.
+- Extend the same determinism to **full-text artifacts** so `paper → its PDF/text` is computable.
+
+**Non-goals**
+- Do **not** redesign the citation/reference-key model. We only mechanically rewrite the id *prefix* embedded in existing reference-key strings during migration.
+- Do **not** introduce human-readable citekeys; ids stay opaque (transparency lives in attributes).
+
+## Decisions (from brainstorming)
+
+| Question | Decision |
+|---|---|
+| Scope | Paper identity (+ full text). Citation model unchanged. |
+| Identity basis | The TypeDB paper id is canonical; external ids (DOI/PMID) are **attributes**, not the name. |
+| Stability | The id is a **deterministic function** of the paper's best stable identifier. |
+| DOI-less papers | **Identifier fallback chain**: DOI → PMID → arXiv/other → content-hash. |
+| Id format | **Pure hash + tier attributes** — preserves the current `scilit-paper-<12hex>` shape. |
+| Full text | **In scope** — deterministic artifact id + per-paper cache path; backfill unlinked PDFs. |
+
+## §1 — The identity function
+
+A single canonical helper `paper_identity(metadata) -> (id, basis_tier, basis_value)`:
+
+```
+# 1. pick the highest-available stable identifier (fallback chain)
+if normalized_doi:        basis_tier, basis_value = "doi",          normalized_doi
+elif pmid:                basis_tier, basis_value = "pmid",         digits_only(pmid)
+elif arxiv_or_other:      basis_tier, basis_value = "arxiv",        normalized_other_id
+else:                     basis_tier, basis_value = "content-hash", f"{norm_title}|{first_author_surname}|{year}"
+
+# 2. deterministic id (tier prefixed so a DOI and a PMID can never collide)
+key = f"{basis_tier}:{basis_value}"
+id  = "scilit-paper-" + sha256(key.encode()).hexdigest()[:12]
+```
+
+**Normalization**
+- **DOI** (`canon_doi`): lowercase; strip `https://doi.org/`, `http://dx.doi.org/`, `doi:` prefixes; strip surrounding whitespace and trailing punctuation. (Harden the existing `canon()` used in `fix_citation_registry.py` and reuse it everywhere.)
+- **PMID**: digits only.
+- **content-hash basis_value**: `norm_title` = lowercased, punctuation stripped, whitespace collapsed; `first_author_surname` = lowercased; `year` = 4 digits. Joined with `|`.
+
+**Stored on every paper**
+- `scilit-identity-basis` — one of `doi | pmid | arxiv | content-hash`.
+- `scilit-identity-value` — the normalized `basis_value` (the transparent, human-inspectable key).
+- `scilit-doi` / `scilit-pmid` remain ordinary attributes (a paper keeps its DOI even when identity falls back, e.g. before a DOI is discovered).
+
+**Collision safety:** 12 hex = 48 bits; birthday-bound ~16M papers for 50% — safe past any realistic corpus. New attributes are additive to `schema.tql`.
+
+## §2 — Ingestion behavior
+
+Every ingestion path (epmc / openalex / bioRxiv / the citation-registry builder / deep-dive paper creation in `make_stragglers`-style code) computes `paper_identity()` and **upserts**:
+- if a paper with that id exists → merge new/better metadata into it (fill missing attrs; never duplicate);
+- else → create it with the deterministic id + basis attrs.
+
+No code path calls `generate_id("scilit-paper")` any more. Dedup is enforced at the door, so the duplicate-DOI class of bug cannot recur.
+
+## §3 — Migration of the existing 426 papers
+
+1. **Backup** (`make db-export`, verify zip).
+2. **Compute** the new id + `scilit-identity-basis`/`-value` for every paper.
+3. **Collision merges:** group papers by computed new id. For any group >1 (the known dup-DOI pair; any stub that now resolves to a DOI):
+   - pick a survivor (prefer the one with the most relations / richest metadata);
+   - re-point every relation of the others onto the survivor (`alh-aboutness`, `scilit-hinge`, `alh-derivation`, `alh-note-threading`, `alh-representation`, `alh-collection-membership`, `alh-classification`, …);
+   - copy any attributes the survivor lacks; delete the extras.
+4. **Swap the `id @key`** in place per surviving paper: `match $p ... has id $old; delete has $old of $p; insert $p has id "<new>";`. **Relations are preserved automatically** — TypeDB binds relations to the entity, not to the id string. Add the basis attrs.
+5. **Rewrite string-embedded ids:** `scilit-reference-key` values (`<citing-id>:<refnum>`) carry the citing paper's *old* id → rewrite the prefix to the new id. The `:refnum` part is untouched.
+
+## §4 — Edge cases & caveats
+
+- **Identifier promotion.** If a content-hash / PMID paper later gains a DOI, its canonical id changes → handle as a **merge** into the DOI-based id (§3.3), not a silent re-key. Rare; documented.
+- **Derived ids stay as-is.** Deep-dive investigation / claim / observation / kefed-model ids embed the *old* 12-hex paper suffix (`scinv-dd-<pid12>`, `scclaim-dd-<pid12>-…`). They keep functioning (opaque handles) but are cosmetically stale after migration. **Decision: leave them.** Only *new* derived ids use the new suffix. Chasing the cascade is churn for no functional gain.
+- **Citation model unchanged.** Only the id prefix inside reference-key strings is rewritten; the `<citing>:<position>` scheme itself is a separate, future concern.
+
+## §5 — Full-text identity (extension)
+
+Full text stays an `alh-artifact` linked by `alh-representation` (`alh-artifact ↔ referent`), but gains **identity derived from the paper + a `kind`**:
+
+- **Kinds:** `pdf` (source PDF), `text` (extracted markdown). Extensible (`html`, `supplement`).
+- **Artifact id:** `scilit-fulltext-<paper-hash>-<kind>` (`paper-hash` = the paper id's 12-hex suffix). Exactly **one artifact per (paper, kind)**, deterministic → upsert. New attribute `scilit-fulltext-kind`.
+- **Cache path (per-paper directory):** `fulltext/<paper-id>/source.pdf`, `fulltext/<paper-id>/text.md`. Fully computable from the paper id; uniform across all identifier tiers (works for DOI-less papers).
+
+**Backfill + relocation migration**
+- For each held paper, if a source PDF exists at `cache/pdf/<normalized-doi>.pdf`, place it at `fulltext/<paper-id>/source.pdf` and create/relink the `pdf` artifact via `alh-representation` — connecting the **~312 currently-unlinked** papers.
+- Re-key the **114 existing** full-text artifacts to deterministic ids; relocate their cache files into the new layout; extracted text → `fulltext/<paper-id>/text.md`.
+- The `alh-representation` links survive the paper-id swap regardless; this step additionally normalizes artifact ids/paths.
+- **Relocation = symlink by default** (the ~412 PDFs are GB-scale; avoid doubling disk). A `--move` flag physically relocates instead.
+
+## Verification
+
+- `paper_identity()` is pure and deterministic: same metadata → same id across processes; unit tests on each tier + normalization edge cases.
+- Post-migration: 0 duplicate-DOI records; every paper has `scilit-identity-basis`/`-value`; relation counts unchanged (spot-check aboutness / hinges / derivations before vs after); reference-key prefixes resolve to existing paper ids.
+- Re-running ingestion over the same inputs creates **0 new papers** (idempotent upsert).
+- Full text: every held paper with a cached PDF has a linked `pdf` artifact at `fulltext/<paper-id>/source.pdf`; `paper → fulltext` resolvable by pure path computation.
+- Spot-check the known collision (`10.1056/nejmoa1805819`) collapses to a single record with all relations retained.
+
+## Deferred / future
+
+- Redesign the citation/reference-key model to a position-independent `cites(citing → cited)` edge keyed by the cited paper's identity (separate spec).
+- Promote `paper_identity` + the full-text layout to a shared core utility if other skills adopt them.

--- a/skills/biomed/scientific-literature/docs/paper-identity-plan.md
+++ b/skills/biomed/scientific-literature/docs/paper-identity-plan.md
@@ -459,6 +459,11 @@ git commit -m "feat(scilit): paper-identity migration (re-key + dup-DOI merge + 
 
 ### Task 5: Full-text identity + backfill
 
+> **SUPERSEDED naming (2026-06-24):** the `source.pdf`/`text.md` + `scilit-fulltext-<paper-hash>-<kind>`
+> scheme in this task was later replaced by one `scilit-fulltext-<paper-hash>` artifact per paper with
+> renditions named by the artifact id (`fulltext/<paper-id>/scilit-fulltext-<paper-hash>.pdf`/`.txt`),
+> moved (not symlinked), with a complete file xref. See `SKILL.md` + `prototypes/rename_fulltext_artifact_files.py`.
+
 **Files:**
 - Create: `prototypes/migrate_fulltext_identity.py`
 

--- a/skills/biomed/scientific-literature/docs/paper-identity-plan.md
+++ b/skills/biomed/scientific-literature/docs/paper-identity-plan.md
@@ -1,0 +1,571 @@
+# Deterministic Paper Identity — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a `scilit-paper`'s TypeDB id a deterministic function of its best stable identifier (DOI→PMID→arXiv→content-hash), dedup by construction, and extend the same determinism to full-text artifacts.
+
+**Architecture:** A new pure-Python module `paper_identity.py` computes `(id, basis_tier, basis_value)` with no DB access (unit-testable). Ingestion routes all paper creation through an `upsert_paper()` helper that uses it. Two run-and-verify migration scripts re-key existing data (paper ids; full-text artifacts) against the live TypeDB, exploiting the fact that a TypeDB `id @key` swap preserves all relations.
+
+**Tech Stack:** Python 3.12, `typedb-driver` 3.8, TypeDB 3.8, pytest, `uv`.
+
+**Reference spec:** `docs/paper-identity-design.md` (this skill).
+
+## Global Constraints
+
+- **Python 3.12 only** — `typedb-driver` segfaults on 3.14. Run everything with `uv run python` from the worktree; if a fresh `.venv` appears, `uv sync --all-extras --python 3.12`.
+- **TypeDB 3.8 rules:** never a variable-free schema match (`match X sub Y;` with two concrete labels crashes the server — always bind a variable). Relation match uses `links`: `$r isa T, links (role: $x)`. Delete an owned attribute with `delete has $v of $e;`. Delete an entity/relation with `delete $x;` (no type qualifier).
+- **String literals:** always `escape_string(...)` user/content strings; generate JSON with `ensure_ascii=False` (a `\uXXXX` escape reaching a TypeQL literal panics the server). Raw UTF-8 in literals is fine.
+- **Always `make db-export` and verify the zip before any schema change or migration `--apply`.**
+- **id `@key` swap preserves relations** — relations bind to the entity, not the id string. This is load-bearing for the migration.
+- Run all commands from the worktree root `/Users/gullyburns/skillful-alhazen/.claude/worktrees/kqed`; the scilit skill resolves via `local_skills/scientific-literature`. Import helpers as `import kqed as K` after `sys.path.insert(0, "<skill-root>")`.
+
+---
+
+### Task 1: Pure identity function + test harness
+
+**Files:**
+- Create: `paper_identity.py`
+- Create: `tests/__init__.py` (empty)
+- Create: `tests/test_paper_identity.py`
+
+**Interfaces:**
+- Produces: `canon_doi(doi: str|None) -> str`, `content_basis(title, first_author, year) -> str`, `paper_identity(meta: dict) -> tuple[str, str, str]` returning `(paper_id, basis_tier, basis_value)`. `meta` keys (all optional): `doi`, `pmid`, `arxiv`, `title`, `first_author`, `year`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_paper_identity.py
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from paper_identity import canon_doi, content_basis, paper_identity
+
+def test_canon_doi_strips_prefixes_and_lowercases():
+    assert canon_doi("https://doi.org/10.1016/J.Cell.2022.11.001") == "10.1016/j.cell.2022.11.001"
+    assert canon_doi("doi:10.1038/NATURE19768") == "10.1038/nature19768"
+    assert canon_doi("  10.1111/acel.13524.  ") == "10.1111/acel.13524"
+    assert canon_doi(None) == "" and canon_doi("") == ""
+
+def test_identity_is_deterministic_and_doi_first():
+    pid1, tier, val = paper_identity({"doi": "10.1016/j.cell.2022.11.001", "pmid": "36599349"})
+    pid2, _, _ = paper_identity({"doi": "HTTPS://doi.org/10.1016/J.CELL.2022.11.001"})
+    assert pid1 == pid2                      # normalization → same id
+    assert tier == "doi" and val == "10.1016/j.cell.2022.11.001"
+    assert pid1.startswith("scilit-paper-") and len(pid1) == len("scilit-paper-") + 12
+
+def test_fallback_chain_pmid_then_arxiv_then_content():
+    assert paper_identity({"pmid": "16904174"})[1] == "pmid"
+    assert paper_identity({"arxiv": "2301.00001"})[1] == "arxiv"
+    pid, tier, val = paper_identity({"title": "The Hallmarks of Aging", "first_author": "Lopez-Otin", "year": 2023})
+    assert tier == "content-hash" and val == "the hallmarks of aging|lopez-otin|2023"
+
+def test_tiers_do_not_collide():
+    # a DOI string and a PMID string that look alike must not produce the same id
+    a, _, _ = paper_identity({"doi": "12345"})
+    b, _, _ = paper_identity({"pmid": "12345"})
+    assert a != b
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/gullyburns/skillful-alhazen/.claude/worktrees/kqed && uv run --with pytest pytest local_skills/scientific-literature/tests/test_paper_identity.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'paper_identity'`.
+
+- [ ] **Step 3: Implement the module**
+
+```python
+# paper_identity.py
+"""Deterministic identity for scilit-paper, derived from the best available
+stable identifier (DOI -> PMID -> arXiv -> content-hash). Pure functions, no DB."""
+import hashlib, re
+
+_DOI_PREFIX = re.compile(r'^(https?://(dx\.)?doi\.org/|doi:)', re.I)
+
+def canon_doi(doi):
+    if not doi:
+        return ""
+    s = _DOI_PREFIX.sub("", str(doi).strip())
+    return s.strip().strip(".").lower()
+
+def _norm_title(t):
+    s = re.sub(r'[^a-z0-9]+', ' ', (t or "").lower())
+    return re.sub(r'\s+', ' ', s).strip()
+
+def content_basis(title, first_author, year):
+    return f"{_norm_title(title)}|{(first_author or '').strip().lower()}|{str(year or '').strip()}"
+
+def paper_identity(meta):
+    """meta: {doi?, pmid?, arxiv?, title?, first_author?, year?}.
+    Returns (paper_id, basis_tier, basis_value)."""
+    doi = canon_doi(meta.get("doi"))
+    if doi:
+        tier, value = "doi", doi
+    elif meta.get("pmid"):
+        tier, value = "pmid", re.sub(r'\D', '', str(meta["pmid"]))
+    elif meta.get("arxiv"):
+        tier, value = "arxiv", str(meta["arxiv"]).strip().lower()
+    else:
+        tier, value = "content-hash", content_basis(meta.get("title"), meta.get("first_author"), meta.get("year"))
+    pid = "scilit-paper-" + hashlib.sha256(f"{tier}:{value}".encode("utf-8")).hexdigest()[:12]
+    return pid, tier, value
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/gullyburns/skillful-alhazen/.claude/worktrees/kqed && uv run --with pytest pytest local_skills/scientific-literature/tests/test_paper_identity.py -v`
+Expected: PASS (4 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/Documents/GitHub/alhazen-skill-examples
+git add skills/biomed/scientific-literature/paper_identity.py skills/biomed/scientific-literature/tests/
+git commit -m "feat(scilit): deterministic paper_identity() pure function + tests"
+```
+
+---
+
+### Task 2: Schema additions (identity + full-text attributes)
+
+**Files:**
+- Modify: `schema.tql` (add three attributes + two `owns` extensions)
+
+**Interfaces:**
+- Produces: attributes `scilit-identity-basis`, `scilit-identity-value` owned by `scilit-paper`; `scilit-fulltext-kind` owned by `alh-artifact` (additive extension of the core type — owns only, no re-typing).
+
+- [ ] **Step 1: Back up the DB**
+
+Run: `cd /Users/gullyburns/skillful-alhazen && make db-export`
+Expected: a new zip under `~/.alhazen/cache/typedb/`; note its path.
+
+- [ ] **Step 2: Add the attribute declarations to `schema.tql`**
+
+Find the scilit attribute block (near `scilit-doi`, `scilit-reference-key`) and add:
+
+```tql
+attribute scilit-identity-basis, value string;   # doi | pmid | arxiv | content-hash
+attribute scilit-identity-value, value string;    # the normalized basis key
+attribute scilit-fulltext-kind, value string;     # pdf | text | html | supplement
+```
+
+In the `entity scilit-paper` definition, add to its `owns` list:
+
+```tql
+    owns scilit-identity-basis,
+    owns scilit-identity-value,
+```
+
+After the entity definitions, additively extend the core artifact type (owns only):
+
+```tql
+alh-artifact owns scilit-fulltext-kind;
+```
+
+- [ ] **Step 3: Apply the schema delta to the live DB**
+
+Run:
+```bash
+cd /Users/gullyburns/skillful-alhazen/.claude/worktrees/kqed
+uv run python - <<'PY'
+import sys; sys.path.insert(0, "/Users/gullyburns/Documents/GitHub/alhazen-skill-examples/skills/biomed/scientific-literature")
+import kqed as K
+from typedb.driver import TransactionType
+d = K.get_driver()
+delta = '''define
+attribute scilit-identity-basis, value string;
+attribute scilit-identity-value, value string;
+attribute scilit-fulltext-kind, value string;
+scilit-paper owns scilit-identity-basis, owns scilit-identity-value;
+alh-artifact owns scilit-fulltext-kind;'''
+with d.transaction("alhazen_notebook", TransactionType.SCHEMA) as tx:
+    tx.query(delta).resolve(); tx.commit()
+print("schema applied")
+d.close()
+PY
+```
+Expected: `schema applied` with no error.
+
+- [ ] **Step 4: Verify the attributes exist**
+
+Run:
+```bash
+uv run python - <<'PY'
+import sys; sys.path.insert(0, "/Users/gullyburns/Documents/GitHub/alhazen-skill-examples/skills/biomed/scientific-literature")
+import kqed as K
+d = K.get_driver()
+# bound-variable schema query (never variable-free)
+print([row.get("a").get_label().name for row in K.r(d, 'match $a label scilit-identity-basis; select $a;')] if False else "ok")
+# functional check: write+read a temp value on a real paper, then delete it
+pid = K.r(d, 'match $p isa scilit-paper, has id $id; fetch {"id":$id};')[0]["id"]
+K.w(d, f'match $p isa scilit-paper, has id "{pid}"; insert $p has scilit-identity-basis "doi";')
+ok = K._has(d, f'$p isa scilit-paper, has id "{pid}", has scilit-identity-basis "doi";')
+K.w(d, f'match $p isa scilit-paper, has id "{pid}", has scilit-identity-basis $v; delete has $v of $p;')
+print("attr usable:", ok)
+d.close()
+PY
+```
+Expected: `attr usable: True`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/Documents/GitHub/alhazen-skill-examples
+git add skills/biomed/scientific-literature/schema.tql
+git commit -m "feat(scilit): schema attrs for paper identity + full-text kind"
+```
+
+---
+
+### Task 3: `upsert_paper()` + route creation through it
+
+**Files:**
+- Modify: `kqed.py` (add `upsert_paper`; route the `generate_id("scilit-paper")` creation at ~line 230 through it)
+- Modify: `prototypes/build_citation_registry.py:101` (route its paper creation through `upsert_paper`)
+- Create: `tests/test_upsert_paper.py`
+
+**Interfaces:**
+- Consumes: `paper_identity` (Task 1); `kqed` helpers `get_driver`, `w`, `r`, `_exists`, `_has`, `escape_string`, `get_timestamp`.
+- Produces: `kqed.upsert_paper(driver, meta: dict) -> str` — computes identity, creates the paper if absent (with `scilit-identity-basis/-value` + any of `name/scilit-doi/scilit-pmid/year/journal` present in `meta`), else fills only missing attrs; returns the deterministic paper id. Idempotent.
+
+- [ ] **Step 1: Write the failing test** (DB-touching; uses a throwaway DOI and cleans up)
+
+```python
+# tests/test_upsert_paper.py
+import os, sys
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+import kqed as K
+from paper_identity import paper_identity
+
+def test_upsert_is_idempotent_and_deterministic():
+    d = K.get_driver()
+    try:
+        meta = {"doi": "10.9999/itest.paper.identity", "name": "Test Paper", "pmid": "99999999"}
+        expected_id, _, _ = paper_identity(meta)
+        K.w(d, f'match $p isa scilit-paper, has id "{expected_id}"; delete $p;') if K._exists(d, expected_id) else None
+        id1 = K.upsert_paper(d, meta)
+        id2 = K.upsert_paper(d, meta)            # second call must not create a duplicate
+        assert id1 == id2 == expected_id
+        count = sum(1 for _ in K.r(d, f'match $p isa scilit-paper, has id "{expected_id}"; select $p;'))
+        assert count == 1
+        assert K._has(d, f'$p isa scilit-paper, has id "{expected_id}", has scilit-identity-basis "doi";')
+    finally:
+        K.w(d, f'match $p isa scilit-paper, has id "{expected_id}"; delete $p;')
+        d.close()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/gullyburns/skillful-alhazen/.claude/worktrees/kqed && uv run --with pytest pytest local_skills/scientific-literature/tests/test_upsert_paper.py -v`
+Expected: FAIL — `AttributeError: module 'kqed' has no attribute 'upsert_paper'`.
+
+- [ ] **Step 3: Implement `upsert_paper` in `kqed.py`**
+
+Add near the other helpers (and `from paper_identity import paper_identity` at the top of `kqed.py`):
+
+```python
+def upsert_paper(driver, meta):
+    """Find-or-create a scilit-paper by deterministic identity. Returns its id."""
+    pid, tier, value = paper_identity(meta)
+    if not _exists(driver, pid):
+        ts = get_timestamp()
+        attrs = [f'has id "{pid}"',
+                 f'has scilit-identity-basis "{escape_string(tier)}"',
+                 f'has scilit-identity-value "{escape_string(value)}"',
+                 f'has created-at {ts}']
+        if meta.get("name") or meta.get("title"):
+            attrs.append(f'has name "{escape_string((meta.get("name") or meta.get("title"))[:200])}"')
+        if meta.get("doi"):
+            attrs.append(f'has scilit-doi "{escape_string(str(meta["doi"]))}"')
+        if meta.get("pmid"):
+            attrs.append(f'has scilit-pmid "{escape_string(str(meta["pmid"]))}"')
+        w(driver, f'insert $p isa scilit-paper, {", ".join(attrs)};')
+    else:
+        # fill only-missing identity attrs (older rows created before this change)
+        if not _has(driver, f'$p isa scilit-paper, has id "{pid}", has scilit-identity-basis $b;'):
+            w(driver, f'match $p isa scilit-paper, has id "{pid}"; '
+                      f'insert $p has scilit-identity-basis "{escape_string(tier)}", '
+                      f'has scilit-identity-value "{escape_string(value)}";')
+    return pid
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/gullyburns/skillful-alhazen/.claude/worktrees/kqed && uv run --with pytest pytest local_skills/scientific-literature/tests/test_upsert_paper.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Route existing creation sites through `upsert_paper`**
+
+In `kqed.py` around line 230 (the `generate_id("scilit-paper")` + `insert ... scilit-paper` block that creates a citation stub), replace the random-id creation with `pid = upsert_paper(driver, {"name": citation})` (keep any caller-supplied DOI/PMID in the meta dict if available). In `prototypes/build_citation_registry.py:101`, replace `pid = generate_id("scilit-paper")` + the following `insert` with `pid = K.upsert_paper(d, {"doi": doi, "name": title, "pmid": pmid})` using the variables already in scope at that point.
+
+- [ ] **Step 6: Re-run both test files; then commit**
+
+Run: `uv run --with pytest pytest local_skills/scientific-literature/tests/ -v` — Expected: all PASS.
+
+```bash
+cd ~/Documents/GitHub/alhazen-skill-examples
+git add skills/biomed/scientific-literature/kqed.py skills/biomed/scientific-literature/prototypes/build_citation_registry.py skills/biomed/scientific-literature/tests/test_upsert_paper.py
+git commit -m "feat(scilit): upsert_paper() + route paper creation through deterministic identity"
+```
+
+---
+
+### Task 4: Paper-identity migration (re-key 426 papers)
+
+**Files:**
+- Create: `prototypes/migrate_paper_identity.py`
+
+**Interfaces:**
+- Consumes: `paper_identity` (Task 1); `kqed` helpers. Dry-run by default; `--apply` writes.
+- Produces: every paper re-keyed to its deterministic id with `scilit-identity-basis/-value` set; duplicate-id groups merged; `scilit-reference-key` prefixes rewritten.
+
+- [ ] **Step 1: Write the migration script**
+
+```python
+#!/usr/bin/env python3
+"""Re-key all scilit-papers to deterministic identity ids. Dry-run unless --apply.
+
+Plan: compute new id per paper; merge collisions (same new id) by re-pointing the
+extras' relations onto a survivor; swap each survivor's id @key in place (relations
+survive); rewrite scilit-reference-key prefixes that embed an old citing-paper id."""
+import os, sys, re
+from collections import defaultdict
+ROOT = "/Users/gullyburns/Documents/GitHub/alhazen-skill-examples/skills/biomed/scientific-literature"
+sys.path.insert(0, ROOT)
+import kqed as K
+from kqed import escape_string
+from paper_identity import paper_identity
+
+# relations a paper plays a role in, with the role name, for collision-merge re-pointing
+PAPER_RELATIONS = [
+    ("alh-aboutness", "subject"), ("scilit-hinge", "hinged-to"),
+    ("alh-derivation", "derived-from-source"), ("alh-representation", "referent"),
+    ("alh-collection-membership", "member"), ("alh-classification", "classified-entity"),
+]
+
+def meta_of(d, pid):
+    g = lambda a: (K.r(d, f'match $p isa scilit-paper, has id "{pid}", has {a} $x; fetch {{"x":$x}};') or [{}])[0].get("x")
+    return {"doi": g("scilit-doi"), "pmid": g("scilit-pmid"), "title": g("name"), "year": g("year")}
+
+def main(apply=False):
+    d = K.get_driver()
+    try:
+        papers = [r["id"] for r in K.r(d, 'match $p isa scilit-paper, has id $id; fetch {"id":$id};')]
+        newid, basis = {}, {}
+        for pid in papers:
+            nid, tier, val = paper_identity(meta_of(d, pid))
+            newid[pid] = nid; basis[pid] = (tier, val)
+        groups = defaultdict(list)
+        for pid, nid in newid.items():
+            groups[nid].append(pid)
+        merges = {nid: olds for nid, olds in groups.items() if len(olds) > 1}
+        print(f"papers={len(papers)} target_ids={len(groups)} collisions={len(merges)}")
+        for nid, olds in list(merges.items())[:10]:
+            print("  merge", olds, "->", nid)
+        if not apply:
+            print("DRY-RUN. Re-run with --apply.")
+            return
+        # 1. merges: keep the paper whose old id already equals nid if present, else first
+        for nid, olds in merges.items():
+            survivor = next((p for p in olds if p == nid), olds[0])
+            for victim in [p for p in olds if p != survivor]:
+                for rel, role in PAPER_RELATIONS:
+                    # re-point: for each rel the victim plays, recreate with survivor, then delete victim's
+                    # (handled generically by swapping the victim's id to a temp then deleting; simplest:
+                    #  move relations by re-inserting survivor into each relation the victim is in)
+                    for row in K.r(d, f'match $v isa scilit-paper, has id "{victim}"; '
+                                     f'$r isa {rel}, links ({role}: $v); fetch {{"r": $r.iid}};') if False else []:
+                        pass
+                # pragmatic re-point: delete victim's relations after copying — see Step 2 note
+                K.w(d, f'match $v isa scilit-paper, has id "{victim}"; delete $v;')
+        # 2. swap id @key for every surviving paper (skip those already at target)
+        for pid in papers:
+            if pid in {p for olds in merges.values() for p in olds if p != (next((q for q in olds if q==newid[pid]), olds[0]))}:
+                continue
+            nid = newid[pid]; tier, val = basis[pid]
+            if pid != nid:
+                K.w(d, f'match $p isa scilit-paper, has id $o; $o == "{pid}"; delete has $o of $p; insert $p has id "{nid}";')
+            if not K._has(d, f'$p isa scilit-paper, has id "{nid}", has scilit-identity-basis $b;'):
+                K.w(d, f'match $p isa scilit-paper, has id "{nid}"; '
+                       f'insert $p has scilit-identity-basis "{escape_string(tier)}", has scilit-identity-value "{escape_string(val)}";')
+        # 3. rewrite reference-key prefixes (old citing-paper id -> new)
+        for r in K.r(d, 'match $p isa scilit-paper, has scilit-reference-key $k; fetch {"id":$p.id,"k":$k};'):
+            k = r["k"]; old = k.split(":")[0]
+            if old in newid and newid[old] != old:
+                nk = newid[old] + ":" + k.split(":",1)[1]
+                K.w(d, f'match $p isa scilit-paper, has id "{r["id"]}", has scilit-reference-key $x; $x == "{escape_string(k)}"; delete has $x of $p;')
+                K.w(d, f'match $p isa scilit-paper, has id "{r["id"]}"; insert $p has scilit-reference-key "{escape_string(nk)}";')
+        print("APPLIED")
+    finally:
+        d.close()
+
+if __name__ == "__main__":
+    main(apply="--apply" in sys.argv)
+```
+
+> **Step 2 note (collision re-point):** TypeDB does not expose a one-call "move all relations from A to B". Implement the victim→survivor re-point explicitly per relation type using the `PAPER_RELATIONS` list: for each relation the victim plays, read its other role-players, `insert` the equivalent relation with the survivor, then `delete` the victim's relation; finally `delete $victim;`. Mirror the concrete delete/insert pattern already proven in `prototypes/fix_citation_registry.py` (hinge re-point) and `prototypes/dedup.py` (relation delete+reinsert). Only 1 known collision today (`10.1056/nejmoa1805819`), so this path runs rarely — but it must be correct.
+
+- [ ] **Step 2: Back up, then dry-run**
+
+```bash
+cd /Users/gullyburns/skillful-alhazen && make db-export
+cd /Users/gullyburns/skillful-alhazen/.claude/worktrees/kqed
+uv run python /Users/gullyburns/Documents/GitHub/alhazen-skill-examples/skills/biomed/scientific-literature/prototypes/migrate_paper_identity.py
+```
+Expected: `papers=426 target_ids=425 collisions=1` and `merge [...] -> ...` for the nejmoa pair; ends `DRY-RUN.`
+
+- [ ] **Step 3: Capture pre-migration relation counts (for the invariant check)**
+
+```bash
+uv run python - <<'PY'
+import sys; sys.path.insert(0, "/Users/gullyburns/Documents/GitHub/alhazen-skill-examples/skills/biomed/scientific-literature")
+import kqed as K
+d=K.get_driver()
+for rel in ["alh-aboutness","scilit-hinge","alh-derivation","alh-representation"]:
+    print(rel, sum(1 for _ in K.r(d, f'match $r isa {rel}; select $r;')))
+d.close()
+PY
+```
+Record these numbers.
+
+- [ ] **Step 4: Apply, then verify the invariants**
+
+```bash
+uv run python .../prototypes/migrate_paper_identity.py --apply
+```
+Then re-run the Step 3 count snippet. Expected: `scilit-hinge`, `alh-derivation`, `alh-representation` counts **unchanged**; `alh-aboutness` down by exactly the merged victim's aboutness edges (or unchanged if re-pointed). Also assert:
+```bash
+uv run python - <<'PY'
+import sys; sys.path.insert(0, "/Users/gullyburns/Documents/GitHub/alhazen-skill-examples/skills/biomed/scientific-literature")
+import kqed as K
+from collections import Counter
+d=K.get_driver()
+c=Counter((r["x"] or "").strip().lower() for r in K.r(d,'match $p isa scilit-paper, has scilit-doi $x; fetch {"x":$x};'))
+print("duplicate DOIs remaining:", sum(1 for v in c.values() if v>1))   # expect 0
+print("papers missing identity-basis:", sum(1 for _ in K.r(d,'match $p isa scilit-paper; not {$p has scilit-identity-basis $b;}; select $p;')))  # expect 0
+d.close()
+PY
+```
+Expected: `duplicate DOIs remaining: 0`, `papers missing identity-basis: 0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/Documents/GitHub/alhazen-skill-examples
+git add skills/biomed/scientific-literature/prototypes/migrate_paper_identity.py
+git commit -m "feat(scilit): paper-identity migration (re-key + dup-DOI merge + ref-key rewrite)"
+```
+
+---
+
+### Task 5: Full-text identity + backfill
+
+**Files:**
+- Create: `prototypes/migrate_fulltext_identity.py`
+
+**Interfaces:**
+- Consumes: `kqed` helpers; the per-paper id from the live graph. `--apply` writes; `--move` physically relocates PDFs (default symlinks).
+- Produces: one `alh-artifact` per `(paper, kind)` with id `scilit-fulltext-<paper-hash>-<kind>`, `scilit-fulltext-kind` set, `cache-path` = `fulltext/<paper-id>/source.pdf|text.md`, linked via `alh-representation`; the ~312 papers with a cached DOI-named PDF but no link get backfilled.
+
+- [ ] **Step 1: Write the script**
+
+```python
+#!/usr/bin/env python3
+"""Deterministic full-text artifacts + backfill. Dry-run unless --apply; symlink unless --move."""
+import os, sys, glob, re
+ROOT = "/Users/gullyburns/Documents/GitHub/alhazen-skill-examples/skills/biomed/scientific-literature"
+sys.path.insert(0, ROOT)
+import kqed as K
+from kqed import escape_string, get_timestamp
+CACHE = os.path.expanduser("~/.alhazen/cache")
+
+def canon_doi_fname(doi):  # cache/pdf uses normalized DOI with '/'->'_'
+    return (doi or "").strip().lower().replace("/", "_")
+
+def main(apply=False, move=False):
+    d = K.get_driver()
+    try:
+        rows = K.r(d, 'match $p isa scilit-paper, has id $id, has scilit-doi $doi; fetch {"id":$id,"doi":$doi};')
+        plan = []
+        for r in rows:
+            pid, doi = r["id"], r["doi"]
+            src = os.path.join(CACHE, "pdf", canon_doi_fname(doi) + ".pdf")
+            if not os.path.exists(src):
+                continue
+            aid = f"scilit-fulltext-{pid.split('-')[-1]}-pdf"
+            dst_rel = f"fulltext/{pid}/source.pdf"
+            linked = K._has(d, f'$p isa scilit-paper, has id "{pid}"; $a isa alh-artifact, has id "{aid}"; '
+                              f'(alh-artifact: $a, referent: $p) isa alh-representation;')
+            plan.append((pid, aid, src, dst_rel, linked))
+        print(f"papers-with-cached-pdf={len(plan)} already-linked={sum(1 for x in plan if x[4])} "
+              f"to-backfill={sum(1 for x in plan if not x[4])}")
+        if not apply:
+            print("DRY-RUN."); return
+        for pid, aid, src, dst_rel, linked in plan:
+            dst = os.path.join(CACHE, dst_rel)
+            os.makedirs(os.path.dirname(dst), exist_ok=True)
+            if not os.path.exists(dst):
+                (os.rename if move else os.symlink)(src, dst)
+            if not K._exists(d, aid):
+                ts = get_timestamp()
+                K.w(d, f'insert $a isa alh-artifact, has id "{aid}", has cache-path "{escape_string(dst_rel)}", '
+                       f'has scilit-fulltext-kind "pdf", has format "application/pdf", has created-at {ts};')
+            if not linked:
+                K.w(d, f'match $a isa alh-artifact, has id "{aid}"; $p isa scilit-paper, has id "{pid}"; '
+                       f'insert (alh-artifact: $a, referent: $p) isa alh-representation;')
+        print("APPLIED")
+    finally:
+        d.close()
+
+if __name__ == "__main__":
+    main(apply="--apply" in sys.argv, move="--move" in sys.argv)
+```
+
+> Note: this task covers `kind="pdf"` (the cached source). Extracted-`text` artifacts are produced during deep-dive extraction; a follow-up step (not blocking) writes them to `fulltext/<paper-id>/text.md` with id `scilit-fulltext-<paper-hash>-text` using the same pattern.
+
+- [ ] **Step 2: Back up, then dry-run**
+
+```bash
+cd /Users/gullyburns/skillful-alhazen && make db-export
+cd /Users/gullyburns/skillful-alhazen/.claude/worktrees/kqed
+uv run python .../prototypes/migrate_fulltext_identity.py
+```
+Expected: `papers-with-cached-pdf=~400 already-linked=~114 to-backfill=~290` then `DRY-RUN.`
+
+- [ ] **Step 3: Apply (symlink default), then verify**
+
+```bash
+uv run python .../prototypes/migrate_fulltext_identity.py --apply
+uv run python - <<'PY'
+import os, sys; sys.path.insert(0, "/Users/gullyburns/Documents/GitHub/alhazen-skill-examples/skills/biomed/scientific-literature")
+import kqed as K
+d=K.get_driver()
+n=sum(1 for _ in K.r(d,'match $p isa scilit-paper; $a isa alh-artifact, has scilit-fulltext-kind "pdf"; (alh-artifact:$a, referent:$p) isa alh-representation; select $p;'))
+print("papers linked to a pdf full-text artifact:", n)
+# pure-path computability check on one paper
+pid=K.r(d,'match $a isa alh-artifact, has scilit-fulltext-kind "pdf"; (alh-artifact:$a, referent:$p) isa alh-representation; $p has id $id; fetch {"id":$id};')[0]["id"]
+print("computed path exists:", os.path.exists(os.path.expanduser(f"~/.alhazen/cache/fulltext/{pid}/source.pdf")))
+d.close()
+PY
+```
+Expected: linked count ≈ papers-with-cached-pdf; `computed path exists: True`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd ~/Documents/GitHub/alhazen-skill-examples
+git add skills/biomed/scientific-literature/prototypes/migrate_fulltext_identity.py
+git commit -m "feat(scilit): full-text artifact identity + backfill of cached PDFs"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** §1 identity fn → Task 1. §2 ingestion upsert → Task 3. §3 paper migration (re-key, dup-DOI merge, ref-key rewrite) → Task 4. §4 edge cases: derived-ids-left-stale (no task, by design — documented in spec); identifier-promotion handled by Task 4's merge path. §5 full-text identity + backfill + symlink default → Task 5. Schema for new attrs → Task 2. All covered.
+- **Placeholder scan:** the one soft spot is Task 4 Step-2 note (collision re-point) — it points at the proven `fix_citation_registry.py`/`dedup.py` patterns rather than inlining all six relation re-point blocks, because there is exactly 1 collision in the data and the per-relation code is mechanical delete+reinsert. Implementer must write the explicit re-point per `PAPER_RELATIONS`; flagged clearly.
+- **Type consistency:** `paper_identity(meta) -> (id, tier, value)` used identically in Tasks 1/3/4; `upsert_paper(driver, meta) -> id` used in Task 3; cache layout `fulltext/<paper-id>/source.pdf` consistent across §5 and Task 5.
+
+## Notes / risks
+
+- The collision-merge (Task 4) is the only genuinely fiddly part; today it affects 1 paper. Keep its dry-run output and verify relation-count invariants before/after.
+- `make build` must never run in the worktree (drops/loads schema into the shared DB); apply schema deltas with the explicit `define` transaction in Task 2 only.

--- a/skills/biomed/scientific-literature/kqed.py
+++ b/skills/biomed/scientific-literature/kqed.py
@@ -248,7 +248,7 @@ def upsert_paper(driver, meta):
     return pid
 
 
-def find_or_make_stub_paper(driver, citation, pid=None):
+def find_or_make_stub_paper(driver, citation):
     """Lightweight scilit-paper stub for a hinge target (cited existing KC)."""
     hit = r(driver, f'match $p isa scilit-paper, has name $n; $n == "{escape_string(citation)}"; fetch {{"id": $p.id}};')
     if hit:

--- a/skills/biomed/scientific-literature/kqed.py
+++ b/skills/biomed/scientific-literature/kqed.py
@@ -12,6 +12,7 @@ alh-classification (which carries provenance + confidence) — not inline enums.
 """
 import os, sys, json, re, argparse
 from typedb.driver import TypeDB, Credentials, DriverOptions, TransactionType
+from paper_identity import paper_identity
 
 try:
     from skillful_alhazen.utils.skill_helpers import escape_string, generate_id, get_timestamp
@@ -222,16 +223,40 @@ def add_addresses(driver, note_id, gap_id):
               f'insert (addressing-note: $n, gap: $g) isa scilit-addresses;')
 
 
+def upsert_paper(driver, meta):
+    """Find-or-create a scilit-paper by deterministic identity. Returns its id."""
+    pid, tier, value = paper_identity(meta)
+    if not _exists(driver, pid):
+        ts = get_timestamp()
+        attrs = [f'has id "{pid}"',
+                 f'has scilit-identity-basis "{escape_string(tier)}"',
+                 f'has scilit-identity-value "{escape_string(value)}"',
+                 f'has created-at {ts}']
+        if meta.get("name") or meta.get("title"):
+            attrs.append(f'has name "{escape_string((meta.get("name") or meta.get("title"))[:200])}"')
+        if meta.get("doi"):
+            attrs.append(f'has scilit-doi "{escape_string(str(meta["doi"]))}"')
+        if meta.get("pmid"):
+            attrs.append(f'has scilit-pmid "{escape_string(str(meta["pmid"]))}"')
+        w(driver, f'insert $p isa scilit-paper, {", ".join(attrs)};')
+    else:
+        # fill only-missing identity attrs (older rows created before this change)
+        if not _has(driver, f'$p isa scilit-paper, has id "{pid}", has scilit-identity-basis $b;'):
+            w(driver, f'match $p isa scilit-paper, has id "{pid}"; '
+                      f'insert $p has scilit-identity-basis "{escape_string(tier)}", '
+                      f'has scilit-identity-value "{escape_string(value)}";')
+    return pid
+
+
 def find_or_make_stub_paper(driver, citation, pid=None):
     """Lightweight scilit-paper stub for a hinge target (cited existing KC)."""
     hit = r(driver, f'match $p isa scilit-paper, has name $n; $n == "{escape_string(citation)}"; fetch {{"id": $p.id}};')
     if hit:
         return hit[0]["id"]
-    pid = pid or generate_id("scilit-paper")
-    ts = get_timestamp()
-    w(driver, f'insert $p isa scilit-paper, has id "{pid}", has name "{escape_string(citation)}", '
-              f'has provenance "hinge-target-stub", has created-at {ts};')
-    return pid
+    # Route through upsert_paper for deterministic identity; provenance set after.
+    new_pid = upsert_paper(driver, {"name": citation})
+    w(driver, f'match $p isa scilit-paper, has id "{new_pid}"; insert $p has provenance "hinge-target-stub";')
+    return new_pid
 
 
 def _hinge_target_kind(driver, target_id):

--- a/skills/biomed/scientific-literature/paper_identity.py
+++ b/skills/biomed/scientific-literature/paper_identity.py
@@ -1,0 +1,33 @@
+"""Deterministic identity for scilit-paper, derived from the best available
+stable identifier (DOI -> PMID -> arXiv -> content-hash). Pure functions, no DB."""
+import hashlib, re
+
+_DOI_PREFIX = re.compile(r'^(https?://(dx\.)?doi\.org/|doi:)', re.I)
+
+def canon_doi(doi):
+    if not doi:
+        return ""
+    s = _DOI_PREFIX.sub("", str(doi).strip())
+    return s.strip().strip(".").lower()
+
+def _norm_title(t):
+    s = re.sub(r'[^a-z0-9]+', ' ', (t or "").lower())
+    return re.sub(r'\s+', ' ', s).strip()
+
+def content_basis(title, first_author, year):
+    return f"{_norm_title(title)}|{(first_author or '').strip().lower()}|{str(year or '').strip()}"
+
+def paper_identity(meta):
+    """meta: {doi?, pmid?, arxiv?, title?, first_author?, year?}.
+    Returns (paper_id, basis_tier, basis_value)."""
+    doi = canon_doi(meta.get("doi"))
+    if doi:
+        tier, value = "doi", doi
+    elif meta.get("pmid"):
+        tier, value = "pmid", re.sub(r'\D', '', str(meta["pmid"]))
+    elif meta.get("arxiv"):
+        tier, value = "arxiv", str(meta["arxiv"]).strip().lower()
+    else:
+        tier, value = "content-hash", content_basis(meta.get("title"), meta.get("first_author"), meta.get("year"))
+    pid = "scilit-paper-" + hashlib.sha256(f"{tier}:{value}".encode("utf-8")).hexdigest()[:12]
+    return pid, tier, value

--- a/skills/biomed/scientific-literature/prototypes/build_citation_registry.py
+++ b/skills/biomed/scientific-literature/prototypes/build_citation_registry.py
@@ -15,7 +15,7 @@ Run:  uv run python prototypes/build_citation_registry.py
 import os, sys, json, re, glob
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import kqed as K
-from kqed import escape_string, generate_id, get_timestamp
+from kqed import escape_string
 
 REVIEW_PAPER = "scilit-paper-21632e9ffb04"
 REVIEW_DOI   = "10.1016/j.cell.2022.11.001"
@@ -88,7 +88,6 @@ def main():
             counts[status] += 1; counts[genre] += 1
 
             pid = find_paper_by_doi(d, doi)
-            ts = get_timestamp()
             if pid:
                 counts["reused"] += 1
                 set_single_attr(d, pid, "scilit-acquisition-status", status)
@@ -98,17 +97,16 @@ def main():
                     K.w(d, f'match $p isa scilit-paper, has id "{pid}"; insert $p has scilit-reference-key "{escape_string(refkey)}";')
             else:
                 counts["stub"] += 1
-                pid = generate_id("scilit-paper")
-                nm = escape_string((title or doi)[:200])
-                q = (f'insert $p isa scilit-paper, has id "{pid}", has name "{nm}", '
-                     f'has scilit-doi "{escape_string(doi)}", '
-                     f'has scilit-acquisition-status "{status}", has scilit-target-genre "{genre}", '
-                     f'has scilit-reference-key "{escape_string(refkey)}", has created-at {ts}')
+                pid = K.upsert_paper(d, {"doi": doi, "name": title or doi})
+                set_single_attr(d, pid, "scilit-acquisition-status", status)
+                set_single_attr(d, pid, "scilit-target-genre", genre)
+                if not K._has(d, f'$p isa scilit-paper, has id "{pid}", has scilit-reference-key "{escape_string(refkey)}";'):
+                    K.w(d, f'match $p isa scilit-paper, has id "{pid}"; insert $p has scilit-reference-key "{escape_string(refkey)}";')
                 if journal:
-                    q += f', has scilit-journal-name "{escape_string(journal)}"'
+                    set_single_attr(d, pid, "scilit-journal-name", journal)
                 if year.isdigit():
-                    q += f', has scilit-publication-year {int(year)}'
-                K.w(d, q + ";")
+                    if not K._has(d, f'$p isa scilit-paper, has id "{pid}", has scilit-publication-year $y;'):
+                        K.w(d, f'match $p isa scilit-paper, has id "{pid}"; insert $p has scilit-publication-year {int(year)};')
         print(json.dumps(counts, indent=2))
     finally:
         d.close()

--- a/skills/biomed/scientific-literature/prototypes/consolidate_fulltext_text.py
+++ b/skills/biomed/scientific-literature/prototypes/consolidate_fulltext_text.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Consolidate extracted text into the unified per-paper full-text scheme.
+
+End state per paper: ONE `scilit-pdf-fulltext` artifact `scilit-fulltext-<paper-hash>`,
+renditions `fulltext/<paper-id>/scilit-fulltext-<paper-hash>.{pdf,txt}`, cache-path = the
+.txt when text exists (else .pdf).
+
+A1 (paper has BOTH a unified plain-alh pdf artifact + a legacy scilit-pdf-fulltext text
+   artifact): move the text in, delete the plain-alh pdf artifact (its .pdf stays as the
+   sibling), re-key the legacy (already the right type) to scilit-fulltext-<hash> (id swap
+   preserves its fragments + representation), point cache-path at the .txt.
+A2 (pdf-only plain-alh): re-type to scilit-pdf-fulltext (delete + recreate same id/attrs +
+   re-point representation).
+A3 (legacy text only, e.g. extracted/hallmarks_review.md): re-key it to scilit-fulltext-<hash>,
+   move the file in, point cache-path at it.
+Dry-run unless --apply."""
+import os, sys, shutil
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+import kqed as K
+from kqed import escape_string, get_timestamp
+CACHE = os.path.expanduser("~/.alhazen/cache")
+STR_ATTRS = ["name","source-uri","cache-path","content-hash","mime-type","format","scilit-fulltext-kind"]
+
+def paper_of(d, aid):
+    r = K.r(d, f'match $x isa alh-artifact, has id "{escape_string(aid)}"; '
+               f'(alh-artifact: $x, referent: $p) isa alh-representation; $p isa scilit-paper, has id $pid; '
+               f'fetch {{"pid": $pid}};')
+    return r[0]["pid"] if r else None
+
+def get_attrs(d, aid):
+    out = {}
+    for a in STR_ATTRS:
+        r = K.r(d, f'match $x isa alh-artifact, has id "{escape_string(aid)}", has {a} $v; fetch {{"v": $v}};')
+        if r: out[a] = r[0]["v"]
+    r = K.r(d, f'match $x isa alh-artifact, has id "{escape_string(aid)}", has file-size $v; fetch {{"v": $v}};')
+    if r: out["file-size"] = r[0]["v"]
+    return out
+
+def n_frags(d, aid):
+    return sum(1 for _ in K.r(d, f'match $a isa alh-artifact, has id "{escape_string(aid)}"; '
+                                 f'(whole: $a, part: $f) isa alh-fragmentation; select $f;'))
+
+def set_cache_path(d, aid, rel):
+    if K._has(d, f'$a isa alh-artifact, has id "{escape_string(aid)}", has cache-path $v;'):
+        K.w(d, f'match $a isa alh-artifact, has id "{escape_string(aid)}", has cache-path $v; delete has $v of $a;')
+    K.w(d, f'match $a isa alh-artifact, has id "{escape_string(aid)}"; insert $a has cache-path "{escape_string(rel)}";')
+
+def rekey(d, old, new):
+    K.w(d, f'match $a isa alh-artifact, has id $o; $o == "{escape_string(old)}"; '
+           f'delete has $o of $a; insert $a has id "{escape_string(new)}";')
+
+def delete_artifact(d, aid):
+    # drop its representation(s) then the entity
+    K.w(d, f'match $a isa alh-artifact, has id "{escape_string(aid)}"; '
+           f'$r isa alh-representation, links (alh-artifact: $a); delete $r;')
+    K.w(d, f'match $a isa alh-artifact, has id "{escape_string(aid)}"; delete $a;')
+
+def recreate_as_pdf_fulltext(d, aid, attrs, paper_id):
+    parts = [f'has id "{escape_string(aid)}"']
+    for k in STR_ATTRS:
+        if attrs.get(k) is not None:
+            parts.append(f'has {k} "{escape_string(str(attrs[k]))}"')
+    if attrs.get("file-size") is not None:
+        parts.append(f'has file-size {int(attrs["file-size"])}')
+    parts.append(f'has created-at {get_timestamp()}')
+    K.w(d, f'insert $a isa scilit-pdf-fulltext, {", ".join(parts)};')
+    K.w(d, f'match $a isa scilit-pdf-fulltext, has id "{escape_string(aid)}"; $p isa scilit-paper, has id "{escape_string(paper_id)}"; '
+           f'insert (alh-artifact: $a, referent: $p) isa alh-representation;')
+
+def ensure_pdf_fulltext_type(d, aid, paper_id):
+    """Guarantee `aid` is typed scilit-pdf-fulltext. No-op when it already is (the common
+    A1/A3 legacy artifact). For a legacy text artifact that was a plain alh-artifact (the
+    extracted/hallmarks_review.md case), re-type via delete+recreate, preserving its
+    representation (recreated) and its fragment links (fragment entities survive the
+    artifact delete; we re-link them). TypeDB 3.x has no in-place re-type."""
+    if K._has(d, f'$a isa scilit-pdf-fulltext, has id "{escape_string(aid)}";'):
+        return
+    attrs = get_attrs(d, aid)
+    frags = [row["fid"] for row in K.r(d,
+        f'match $a isa alh-artifact, has id "{escape_string(aid)}"; '
+        f'(whole: $a, part: $f) isa alh-fragmentation; $f isa alh-fragment, has id $fid; '
+        f'fetch {{"fid": $fid}};')]
+    delete_artifact(d, aid)                       # drops representation + fragmentation relations
+    recreate_as_pdf_fulltext(d, aid, attrs, paper_id)
+    for fid in frags:                             # fragment entities survived; re-link them
+        K.w(d, f'match $a isa scilit-pdf-fulltext, has id "{escape_string(aid)}"; '
+               f'$f isa alh-fragment, has id "{escape_string(fid)}"; '
+               f'insert (whole: $a, part: $f) isa alh-fragmentation;')
+
+def main(apply=False):
+    d = K.get_driver()
+    try:
+        unified, legacy = {}, {}
+        for r in K.r(d, 'match $a isa alh-artifact, has id $aid, has cache-path $cp; fetch {"aid": $aid, "cp": $cp};'):
+            aid, cp = r["aid"], r["cp"]
+            if cp.startswith("fulltext/") and cp.endswith(".pdf") and aid.startswith("scilit-fulltext-"):
+                p = paper_of(d, aid);  unified[p] = (aid, cp) if p else unified.get(p)
+            elif cp.startswith("text/") or cp.startswith("extracted/"):
+                p = paper_of(d, aid);  legacy[p] = (aid, cp) if p else legacy.get(p)
+        unified.pop(None, None); legacy.pop(None, None)
+        a1 = [p for p in legacy if p in unified]
+        a2 = [p for p in unified if p not in legacy]
+        a3 = [p for p in legacy if p not in unified]
+        fragarts = fragn = 0
+        for p in legacy:
+            n = n_frags(d, legacy[p][0])
+            if n: fragarts += 1; fragn += n
+        # pending = classification keys on cache-path, but the type may already be fixed
+        # (this script is idempotent): count only the artifacts still needing a re-type.
+        a2_pending = sum(1 for p in a2
+                         if not K._has(d, f'$a isa scilit-pdf-fulltext, has id "{escape_string(unified[p][0])}";'))
+        print(f"A1(merge both)={len(a1)} | A2(re-type pdf-only)={len(a2)} (pending={a2_pending}) "
+              f"| A3(legacy-only)={len(a3)} | legacy frag-artifacts={fragarts} frags={fragn}")
+        if not apply:
+            print("DRY-RUN. Re-run with --apply."); return
+        # A1
+        for p in a1:
+            uaid, _ = unified[p]; laid, lcp = legacy[p]
+            ext = ".md" if lcp.endswith(".md") else ".txt"
+            new_txt = f"fulltext/{p}/{uaid}{ext}"
+            src, dst = os.path.join(CACHE, lcp), os.path.join(CACHE, new_txt)
+            os.makedirs(os.path.dirname(dst), exist_ok=True)
+            if os.path.exists(src) and not os.path.exists(dst): shutil.move(src, dst)
+            delete_artifact(d, uaid)          # free the deterministic id (its .pdf stays on disk)
+            rekey(d, laid, uaid)              # legacy survives (fragments preserved by id swap)
+            set_cache_path(d, uaid, new_txt)
+            ensure_pdf_fulltext_type(d, uaid, p)  # re-type if the legacy was a plain alh-artifact
+            if not K._has(d, f'$a isa alh-artifact, has id "{escape_string(uaid)}", has scilit-fulltext-kind $k;'):
+                K.w(d, f'match $a isa alh-artifact, has id "{escape_string(uaid)}"; insert $a has scilit-fulltext-kind "pdf";')
+        # A2 — re-type pdf-only plain alh-artifacts (no fragments). ensure_pdf_fulltext_type
+        # early-returns for any already re-typed, so re-running --apply is a safe no-op.
+        for p in a2:
+            ensure_pdf_fulltext_type(d, unified[p][0], p)
+        # A3
+        for p in a3:
+            laid, lcp = legacy[p]
+            new_aid = f"scilit-fulltext-{p.split('-')[-1]}"
+            ext = ".md" if lcp.endswith(".md") else ".txt"
+            new_rel = f"fulltext/{p}/{new_aid}{ext}"
+            src, dst = os.path.join(CACHE, lcp), os.path.join(CACHE, new_rel)
+            os.makedirs(os.path.dirname(dst), exist_ok=True)
+            if os.path.exists(src) and not os.path.exists(dst): shutil.move(src, dst)
+            rekey(d, laid, new_aid); set_cache_path(d, new_aid, new_rel)
+            ensure_pdf_fulltext_type(d, new_aid, p)  # re-type if the legacy was a plain alh-artifact
+        print(f"APPLIED: A1={len(a1)} A2={len(a2)} A3={len(a3)}")
+    finally:
+        d.close()
+
+if __name__ == "__main__":
+    main(apply="--apply" in sys.argv)

--- a/skills/biomed/scientific-literature/prototypes/fix_citation_registry.py
+++ b/skills/biomed/scientific-literature/prototypes/fix_citation_registry.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""
+Fix the Hallmarks-2023 citation registry: build_citation_registry resolved each
+in-text reference number N by Crossref's `bibNN` KEY, but the correct paper is at
+Crossref ARRAY POSITION N (references are returned in citation order). Result: every
+scilit-reference-key, paper-level scilit-hinge, and scilit-citation-load is misassigned.
+
+This re-resolves number -> paper by array position and rebuilds the linkage:
+  - reset each registry paper's scilit-reference-key to its correct position(s)
+  - re-point every paper-level hinge from the wrong paper to the correct one
+  - recompute scilit-citation-load
+Dry-run by default; pass --apply to write.
+
+Run: uv run python prototypes/fix_citation_registry.py [--apply]
+"""
+import os, sys, re, json, urllib.request
+from collections import Counter, defaultdict
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import kqed as K
+from kqed import escape_string
+
+REVIEW_PAPER = "scilit-paper-21632e9ffb04"
+REVIEW_DOI = "10.1016/j.cell.2022.11.001"
+
+def canon(doi):
+    if not doi: return ""
+    s = str(doi).strip().lower()
+    s = re.sub(r"^https?://(dx\.)?doi\.org/", "", s)
+    return s.strip()
+
+def crossref_positions():
+    url = f"https://api.crossref.org/works/{REVIEW_DOI}"
+    req = urllib.request.Request(url, headers={"User-Agent":"alhazen-kqed/1.0 (mailto:gullyburns@gmail.com)"})
+    refs = json.load(urllib.request.urlopen(req, timeout=30))["message"]["reference"]
+    pos2doi = {}
+    for i, r in enumerate(refs, 1):     # array position (1-based) = in-text number
+        doi = canon(r.get("DOI"))
+        if doi: pos2doi[i] = doi
+    return pos2doi, len(refs)
+
+def main(apply=False):
+    d = K.get_driver()
+    try:
+        pos2doi, ntot = crossref_positions()
+        # registry papers: id -> {doi, refkeys}
+        papers = {}
+        for r in K.r(d, 'match $p isa scilit-paper, has id $id, has scilit-doi $doi; fetch {"id": $id, "doi": $doi};'):
+            papers.setdefault(r["id"], {})["doi"] = canon(r["doi"])
+        for r in K.r(d, 'match $p isa scilit-paper, has id $id, has scilit-reference-key $k; '
+                        f'$k contains "{REVIEW_PAPER}:"; fetch {{"id": $id, "k": $k}};'):
+            papers.setdefault(r["id"], {}).setdefault("rk", []).append(r["k"])
+        doi2paper = {v["doi"]: pid for pid, v in papers.items() if v.get("doi")}
+
+        # correct map: in-text position N -> registry paper (by DOI)
+        pos2paper = {n: doi2paper[doi] for n, doi in pos2doi.items() if doi in doi2paper}
+        # current (buggy) map: a paper's reference-key number M = the in-text number of claims hinged to it
+        paper2num = {}   # pid -> M (its current reference-key number)
+        for pid, v in papers.items():
+            for k in v.get("rk", []):
+                m = re.search(rf"{re.escape(REVIEW_PAPER)}:(\d+)", k)
+                if m: paper2num[pid] = int(m.group(1))
+
+        # paper-level hinges from the BULK review citing-claims only (scclaim-hmref-*);
+        # hand-authored KQED-prototype hinges (e.g. scilit-claim-hm-ref123) are left untouched
+        # because they were not built via the in-text-number -> bibNN mechanism.
+        hinges = []
+        for r in K.r(d, 'match $h isa scilit-hinge, links (hinging-claim: $c, hinged-to: $p); '
+                        '$c isa scilit-claim, has id $cid; $p isa scilit-paper, has id $pid; '
+                        '$h has scilit-hinge-term-id $cfc; fetch {"c": $cid, "p": $pid, "cfc": $cfc};'):
+            if str(r["c"]).startswith("scclaim-hmref-"):
+                hinges.append((r["c"], r["p"], r["cfc"]))
+
+        repoint, keep, drop = [], 0, []
+        for cid, pid, cfc in hinges:
+            M = paper2num.get(pid)              # claim's in-text number
+            correct = pos2paper.get(M) if M else None
+            if correct is None:
+                drop.append((cid, pid, M)); continue
+            if correct == pid: keep += 1
+            else: repoint.append((cid, pid, correct, cfc, M))
+
+        print(json.dumps({
+            "crossref_refs": ntot,
+            "positions_with_doi": len(pos2doi),
+            "positions_resolved_to_registry_paper": len(pos2paper),
+            "registry_papers_with_doi": len(doi2paper),
+            "paper_level_hinges": len(hinges),
+            "hinges_already_correct": keep,
+            "hinges_to_REPOINT": len(repoint),
+            "hinges_to_DROP (in-text num -> non-registry paper)": len(drop),
+        }, indent=2))
+        print("\n-- spot check (claim, OLD paper, -> NEW paper, in-text#) --")
+        for cid, old, new, cfc, M in repoint[:8]:
+            print(f"   {cid}: {old} -> {new}  (#{M}, {cfc})")
+
+        if not apply:
+            print("\nDRY-RUN. Re-run with --apply to write.")
+            return
+
+        # APPLY: re-point hinges, reset reference-keys, recompute loads
+        # 1. re-point
+        for cid, old, new, cfc, M in repoint:
+            K.w(d, f'match $c isa scilit-claim, has id "{cid}"; $p isa scilit-paper, has id "{old}"; '
+                   f'$h isa scilit-hinge, links (hinging-claim: $c, hinged-to: $p); delete $h;')
+            K.add_hinge(d, cid, new, cfc, target_kind="scilit-paper")
+        # 2. drop wrong hinges (cite a paper not in registry)
+        for cid, pid, M in drop:
+            K.w(d, f'match $c isa scilit-claim, has id "{cid}"; $p isa scilit-paper, has id "{pid}"; '
+                   f'$h isa scilit-hinge, links (hinging-claim: $c, hinged-to: $p); delete $h;')
+        # 3. reset reference-keys to correct positions
+        for pid, v in papers.items():
+            for k in v.get("rk", []):
+                K.w(d, f'match $p isa scilit-paper, has id "{pid}", has scilit-reference-key $x; '
+                       f'$x == "{escape_string(k)}"; delete has $x of $p;')
+        for n, pid in pos2paper.items():
+            key = f"{REVIEW_PAPER}:{n}"
+            if not K._has(d, f'$p isa scilit-paper, has id "{pid}", has scilit-reference-key $k; $k == "{key}";'):
+                K.w(d, f'match $p isa scilit-paper, has id "{pid}"; insert $p has scilit-reference-key "{key}";')
+        # 4. recompute citation-load from corrected hinges
+        load = Counter()
+        for r in K.r(d, 'match $h isa scilit-hinge, links (hinged-to: $p); $p isa scilit-paper, has id $pid; '
+                        'fetch {"p": $pid};'):
+            load[r["p"]] += 1
+        for pid in set(list(load.keys()) + list(papers.keys())):
+            if K._has(d, f'$p isa scilit-paper, has id "{pid}", has scilit-citation-load $v;'):
+                K.w(d, f'match $p isa scilit-paper, has id "{pid}", has scilit-citation-load $v; delete has $v of $p;')
+            if load.get(pid):
+                K.w(d, f'match $p isa scilit-paper, has id "{pid}"; insert $p has scilit-citation-load {load[pid]};')
+        print("\nAPPLIED:", json.dumps({"repointed": len(repoint), "dropped": len(drop),
+                                        "reference_keys_set": len(pos2paper)}))
+    finally:
+        d.close()
+
+if __name__ == "__main__":
+    main(apply="--apply" in sys.argv)

--- a/skills/biomed/scientific-literature/prototypes/import_deepdive.py
+++ b/skills/biomed/scientific-literature/prototypes/import_deepdive.py
@@ -108,10 +108,16 @@ def import_record(d, paper_id, doi, title, record):
                     except Exception:
                         pass
             models[et] = mid
-        K.add_observation(d, inv, models[et], stmt,
-                          o.get("knowledge_level", "assertion"),
-                          o.get("bio_scale", "molecular"), about=paper_id)
-        out["observations"] += 1
+        # content-idempotent: skip if an observation with this statement already
+        # exists under this investigation (add_observation uses a random id, so we
+        # must dedupe on content, not id)
+        if not K._has(d, f'$i isa scilit-investigation, has id "{inv}"; '
+                        f'$o isa scilit-observation, has content "{escape_string(stmt)}"; '
+                        f'(parent-note: $i, child-note: $o) isa alh-note-threading;'):
+            K.add_observation(d, inv, models[et], stmt,
+                              o.get("knowledge_level", "assertion"),
+                              o.get("bio_scale", "molecular"), about=paper_id)
+            out["observations"] += 1
 
     # ---- gaps (direct insert; no vocab dependency) ----
     for g in record.get("gaps", []):
@@ -136,9 +142,13 @@ def import_record(d, paper_id, doi, title, record):
             continue
         sid = K.add_bioentity(d, s)
         tid = K.add_bioentity(d, t)
-        K.add_mech_link(d, sid, ml.get("type", "activates"), tid,
-                        confidence=ml.get("confidence", 0.8))
-        out["mech_links"] += 1
+        mtype = ml.get("type", "activates")
+        # edge-idempotent: skip if this (source, target, type) link already exists
+        if not K._has(d, f'$s isa scilit-bioentity, has id "{sid}"; $t isa scilit-bioentity, has id "{tid}"; '
+                        f'$r isa scilit-mechanistic-link, links (mech-source: $s, mech-target: $t), '
+                        f'has scilit-mech-type "{escape_string(mtype)}";'):
+            K.add_mech_link(d, sid, mtype, tid, confidence=ml.get("confidence", 0.8))
+            out["mech_links"] += 1
 
     # ---- status + claim-level hinges back to the review ----
     _set_single(d, paper_id, "scilit-acquisition-status", "sensemade")

--- a/skills/biomed/scientific-literature/prototypes/migrate_fulltext_identity.py
+++ b/skills/biomed/scientific-literature/prototypes/migrate_fulltext_identity.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Deterministic full-text artifacts + backfill. Dry-run unless --apply; symlink unless --move."""
+import os, sys, glob, re
+ROOT = "/Users/gullyburns/Documents/GitHub/alhazen-skill-examples/skills/biomed/scientific-literature"
+sys.path.insert(0, ROOT)
+import kqed as K
+from kqed import escape_string, get_timestamp
+CACHE = os.path.expanduser("~/.alhazen/cache")
+
+
+def canon_doi_fname(doi):  # cache/pdf uses normalized DOI with '/'->'_'
+    return (doi or "").strip().lower().replace("/", "_")
+
+
+def main(apply=False, move=False):
+    d = K.get_driver()
+    try:
+        rows = K.r(d, 'match $p isa scilit-paper, has id $id, has scilit-doi $doi; fetch {"id":$id,"doi":$doi};')
+        plan = []
+        for r in rows:
+            pid, doi = r["id"], r["doi"]
+            src = os.path.join(CACHE, "pdf", canon_doi_fname(doi) + ".pdf")
+            if not os.path.exists(src):
+                continue
+            aid = f"scilit-fulltext-{pid.split('-')[-1]}-pdf"
+            dst_rel = f"fulltext/{pid}/source.pdf"
+            linked = K._has(d, f'$p isa scilit-paper, has id "{pid}"; $a isa alh-artifact, has id "{aid}"; '
+                              f'$r isa alh-representation, links (alh-artifact: $a, referent: $p);')
+            plan.append((pid, aid, src, dst_rel, linked))
+        print(f"papers-with-cached-pdf={len(plan)} already-linked={sum(1 for x in plan if x[4])} "
+              f"to-backfill={sum(1 for x in plan if not x[4])}")
+        if not apply:
+            print("DRY-RUN.")
+            return
+        created = 0
+        linked_new = 0
+        symlinked = 0
+        skipped = 0
+        for pid, aid, src, dst_rel, linked in plan:
+            dst = os.path.join(CACHE, dst_rel)
+            os.makedirs(os.path.dirname(dst), exist_ok=True)
+            if not os.path.exists(dst):
+                if move:
+                    os.rename(src, dst)
+                else:
+                    os.symlink(src, dst)
+                symlinked += 1
+            else:
+                skipped += 1
+            if not K._exists(d, aid):
+                ts = get_timestamp()
+                K.w(d, f'insert $a isa alh-artifact, has id "{aid}", has cache-path "{escape_string(dst_rel)}", '
+                       f'has scilit-fulltext-kind "pdf", has format "application/pdf", has created-at {ts};')
+                created += 1
+            if not linked:
+                K.w(d, f'match $a isa alh-artifact, has id "{aid}"; $p isa scilit-paper, has id "{pid}"; '
+                       f'insert (alh-artifact: $a, referent: $p) isa alh-representation;')
+                linked_new += 1
+        print(f"APPLIED: artifacts-created={created} links-created={linked_new} symlinks-new={symlinked} symlinks-skipped={skipped}")
+    finally:
+        d.close()
+
+
+if __name__ == "__main__":
+    main(apply="--apply" in sys.argv, move="--move" in sys.argv)

--- a/skills/biomed/scientific-literature/prototypes/migrate_fulltext_identity.py
+++ b/skills/biomed/scientific-literature/prototypes/migrate_fulltext_identity.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """Deterministic full-text artifacts + backfill. Dry-run unless --apply; symlink unless --move."""
-import os, sys, glob, re
+import os, sys, glob, re, shutil
 ROOT = "/Users/gullyburns/Documents/GitHub/alhazen-skill-examples/skills/biomed/scientific-literature"
 sys.path.insert(0, ROOT)
 import kqed as K
@@ -40,10 +40,7 @@ def main(apply=False, move=False):
             dst = os.path.join(CACHE, dst_rel)
             os.makedirs(os.path.dirname(dst), exist_ok=True)
             if not os.path.exists(dst):
-                if move:
-                    os.rename(src, dst)
-                else:
-                    os.symlink(src, dst)
+                shutil.move(src, dst)   # relocate the source into fulltext/; remove original
                 symlinked += 1
             else:
                 skipped += 1

--- a/skills/biomed/scientific-literature/prototypes/migrate_fulltext_identity.py
+++ b/skills/biomed/scientific-literature/prototypes/migrate_fulltext_identity.py
@@ -22,8 +22,8 @@ def main(apply=False, move=False):
             src = os.path.join(CACHE, "pdf", canon_doi_fname(doi) + ".pdf")
             if not os.path.exists(src):
                 continue
-            aid = f"scilit-fulltext-{pid.split('-')[-1]}-pdf"
-            dst_rel = f"fulltext/{pid}/source.pdf"
+            aid = f"scilit-fulltext-{pid.split('-')[-1]}"
+            dst_rel = f"fulltext/{pid}/{aid}.pdf"
             linked = K._has(d, f'$p isa scilit-paper, has id "{pid}"; $a isa alh-artifact, has id "{aid}"; '
                               f'$r isa alh-representation, links (alh-artifact: $a, referent: $p);')
             plan.append((pid, aid, src, dst_rel, linked))

--- a/skills/biomed/scientific-literature/prototypes/migrate_paper_identity.py
+++ b/skills/biomed/scientific-literature/prototypes/migrate_paper_identity.py
@@ -46,16 +46,21 @@ def meta_of(d, pid):
 
 
 def repoint_relations(d, victim_id, survivor_id):
-    """For each relation the victim plays, re-insert with the survivor, then delete victim's.
+    """For each relation the victim plays, atomically re-point it to the survivor.
 
     We do NOT constrain the concrete type of the other role-player in match clauses;
     instead we identify it only by its id attribute. This avoids TypeDB INF6 errors
     when the other player's declared type is abstract (e.g. 'collection').
+
+    Each re-point is expressed as a single match/insert/delete query so it is atomic
+    within one TypeDB write transaction — a crash cannot leave a duplicate relation.
     """
+    ev = escape_string(victim_id)
+    es = escape_string(survivor_id)
     for rel, victim_role, other_role in PAPER_RELATIONS:
         # Find all relations of this type where victim plays victim_role.
         # Match the other player only by id (no type constraint to avoid INF6).
-        query = (f'match $v isa scilit-paper, has id "{victim_id}"; '
+        query = (f'match $v isa scilit-paper, has id "{ev}"; '
                  f'$r isa {rel}, links ({victim_role}: $v, {other_role}: $o); '
                  f'$o has id $oid; fetch {{"oid": $oid}};')
         try:
@@ -66,27 +71,24 @@ def repoint_relations(d, victim_id, survivor_id):
 
         for row in rows:
             oid = row["oid"]
+            eoid = escape_string(oid)
             # Check if the survivor already has this relation to the same other player
-            # (to avoid duplicate relations after re-pointing)
-            already = K._has(d, (f'$s isa scilit-paper, has id "{survivor_id}"; '
-                                  f'$o has id "{escape_string(oid)}"; '
+            # (to avoid duplicate relations after re-pointing; keeps the op idempotent).
+            already = K._has(d, (f'$s isa scilit-paper, has id "{es}"; '
+                                  f'$o has id "{eoid}"; '
                                   f'$r isa {rel}, links ({victim_role}: $s, {other_role}: $o);'))
             if not already:
-                # Insert the equivalent relation with the survivor.
-                # We match the other player by id only (no type constraint).
-                K.w(d, (f'match $s isa scilit-paper, has id "{survivor_id}"; '
-                         f'$o has id "{escape_string(oid)}"; '
-                         f'insert ({victim_role}: $s, {other_role}: $o) isa {rel};'))
+                # Atomically insert the survivor relation and delete the victim relation
+                # in a single write transaction (match … insert … delete).
+                K.w(d, (f'match $v isa scilit-paper, has id "{ev}"; '
+                         f'$s isa scilit-paper, has id "{es}"; '
+                         f'$o has id "{eoid}"; '
+                         f'$r isa {rel}, links ({victim_role}: $v, {other_role}: $o); '
+                         f'insert ({victim_role}: $s, {other_role}: $o) isa {rel}; '
+                         f'delete $r;'))
                 print(f"    re-pointed {rel} ({other_role}={oid}) from {victim_id} to {survivor_id}")
             else:
                 print(f"    skipped dup {rel} ({other_role}={oid}) - survivor already has it")
-
-            # Delete the victim's relation (match by victim id + other player id).
-            K.w(d, (f'match $v isa scilit-paper, has id "{victim_id}"; '
-                     f'$o has id "{escape_string(oid)}"; '
-                     f'$r isa {rel}, links ({victim_role}: $v, {other_role}: $o); '
-                     f'delete $r;'))
-            print(f"    deleted {rel} from victim {victim_id}")
 
 
 def main(apply=False):
@@ -117,7 +119,6 @@ def main(apply=False):
 
         # 1. Handle collisions: merge victims into survivor
         # survivor = the paper whose old id equals nid if present, else first in list
-        victim_set = set()
         for nid, olds in merges.items():
             survivor = next((p for p in olds if p == nid), olds[0])
             victims = [p for p in olds if p != survivor]
@@ -126,15 +127,8 @@ def main(apply=False):
                 print(f"  Re-pointing relations from victim {victim} to survivor {survivor}")
                 repoint_relations(d, victim, survivor)
                 # Delete the victim entity
-                K.w(d, f'match $v isa scilit-paper, has id "{victim}"; delete $v;')
+                K.w(d, f'match $v isa scilit-paper, has id "{escape_string(victim)}"; delete $v;')
                 print(f"  Deleted victim {victim}")
-                victim_set.add(victim)
-
-        # Build set of victims (to skip during id-swap phase)
-        all_victims = set()
-        for nid, olds in merges.items():
-            survivor = next((p for p in olds if p == nid), olds[0])
-            all_victims.update(p for p in olds if p != survivor)
 
         # 2. Swap id @key for every surviving paper (skip victims, skip already-correct)
         # Re-fetch live paper ids (victims are now deleted)

--- a/skills/biomed/scientific-literature/prototypes/migrate_paper_identity.py
+++ b/skills/biomed/scientific-literature/prototypes/migrate_paper_identity.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Re-key all scilit-papers to deterministic identity ids. Dry-run unless --apply.
+
+Plan: compute new id per paper; merge collisions (same new id) by re-pointing the
+extras' relations onto a survivor; swap each survivor's id @key in place (relations
+survive); rewrite scilit-reference-key prefixes that embed an old citing-paper id.
+
+Run: uv run python prototypes/migrate_paper_identity.py [--apply]
+"""
+import os, sys, re
+from collections import defaultdict
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+import kqed as K
+from kqed import escape_string
+from paper_identity import paper_identity
+
+# Relations a paper plays a role in, with the role name, for collision-merge re-pointing.
+# Each entry: (relation_type, victim_role, other_role)
+# We do NOT restrict the other role-player's concrete type to avoid TypeDB INF6 errors
+# with abstract supertypes (e.g. 'collection' is abstract; actual type is scilit-corpus).
+# Instead we match the other player only by its id attribute.
+PAPER_RELATIONS = [
+    # (rel_type, victim_role, other_role)
+    ("alh-aboutness",             "subject",            "note"),
+    ("scilit-hinge",              "hinged-to",          "hinging-claim"),
+    ("alh-representation",        "referent",           "alh-artifact"),
+    ("alh-collection-membership", "member",             "collection"),
+    ("alh-classification",        "classified-entity",  "type-facet"),
+]
+# alh-derivation: scilit-paper is NOT in the derived-from-source role (that's for fragments).
+# Confirmed by INF11 error during investigation; so we skip it.
+
+
+def meta_of(d, pid):
+    """Fetch the identity attributes of a paper by id."""
+    rows = K.r(d, f'match $p isa scilit-paper, has id "{pid}"; '
+                  f'fetch {{"doi": $p.scilit-doi, "pmid": $p.scilit-pmid, '
+                  f'"title": $p.name}};')
+    row = rows[0] if rows else {}
+    return {
+        "doi":   row.get("doi"),
+        "pmid":  row.get("pmid"),
+        "title": row.get("title"),
+    }
+
+
+def repoint_relations(d, victim_id, survivor_id):
+    """For each relation the victim plays, re-insert with the survivor, then delete victim's.
+
+    We do NOT constrain the concrete type of the other role-player in match clauses;
+    instead we identify it only by its id attribute. This avoids TypeDB INF6 errors
+    when the other player's declared type is abstract (e.g. 'collection').
+    """
+    for rel, victim_role, other_role in PAPER_RELATIONS:
+        # Find all relations of this type where victim plays victim_role.
+        # Match the other player only by id (no type constraint to avoid INF6).
+        query = (f'match $v isa scilit-paper, has id "{victim_id}"; '
+                 f'$r isa {rel}, links ({victim_role}: $v, {other_role}: $o); '
+                 f'$o has id $oid; fetch {{"oid": $oid}};')
+        try:
+            rows = K.r(d, query)
+        except Exception as e:
+            print(f"    WARN: could not query {rel} for {victim_id}: {e}")
+            rows = []
+
+        for row in rows:
+            oid = row["oid"]
+            # Check if the survivor already has this relation to the same other player
+            # (to avoid duplicate relations after re-pointing)
+            already = K._has(d, (f'$s isa scilit-paper, has id "{survivor_id}"; '
+                                  f'$o has id "{escape_string(oid)}"; '
+                                  f'$r isa {rel}, links ({victim_role}: $s, {other_role}: $o);'))
+            if not already:
+                # Insert the equivalent relation with the survivor.
+                # We match the other player by id only (no type constraint).
+                K.w(d, (f'match $s isa scilit-paper, has id "{survivor_id}"; '
+                         f'$o has id "{escape_string(oid)}"; '
+                         f'insert ({victim_role}: $s, {other_role}: $o) isa {rel};'))
+                print(f"    re-pointed {rel} ({other_role}={oid}) from {victim_id} to {survivor_id}")
+            else:
+                print(f"    skipped dup {rel} ({other_role}={oid}) - survivor already has it")
+
+            # Delete the victim's relation (match by victim id + other player id).
+            K.w(d, (f'match $v isa scilit-paper, has id "{victim_id}"; '
+                     f'$o has id "{escape_string(oid)}"; '
+                     f'$r isa {rel}, links ({victim_role}: $v, {other_role}: $o); '
+                     f'delete $r;'))
+            print(f"    deleted {rel} from victim {victim_id}")
+
+
+def main(apply=False):
+    d = K.get_driver()
+    try:
+        # Fetch all scilit-paper ids
+        papers = [r["id"] for r in K.r(d, 'match $p isa scilit-paper, has id $id; fetch {"id": $id};')]
+
+        newid, basis = {}, {}
+        for pid in papers:
+            meta = meta_of(d, pid)
+            nid, tier, val = paper_identity(meta)
+            newid[pid] = nid
+            basis[pid] = (tier, val)
+
+        groups = defaultdict(list)
+        for pid, nid in newid.items():
+            groups[nid].append(pid)
+
+        merges = {nid: olds for nid, olds in groups.items() if len(olds) > 1}
+        print(f"papers={len(papers)} target_ids={len(groups)} collisions={len(merges)}")
+        for nid, olds in list(merges.items())[:10]:
+            print(f"  merge {olds} -> {nid}")
+
+        if not apply:
+            print("DRY-RUN. Re-run with --apply.")
+            return
+
+        # 1. Handle collisions: merge victims into survivor
+        # survivor = the paper whose old id equals nid if present, else first in list
+        victim_set = set()
+        for nid, olds in merges.items():
+            survivor = next((p for p in olds if p == nid), olds[0])
+            victims = [p for p in olds if p != survivor]
+            print(f"\nMerging {victims} -> survivor={survivor} (target={nid})")
+            for victim in victims:
+                print(f"  Re-pointing relations from victim {victim} to survivor {survivor}")
+                repoint_relations(d, victim, survivor)
+                # Delete the victim entity
+                K.w(d, f'match $v isa scilit-paper, has id "{victim}"; delete $v;')
+                print(f"  Deleted victim {victim}")
+                victim_set.add(victim)
+
+        # Build set of victims (to skip during id-swap phase)
+        all_victims = set()
+        for nid, olds in merges.items():
+            survivor = next((p for p in olds if p == nid), olds[0])
+            all_victims.update(p for p in olds if p != survivor)
+
+        # 2. Swap id @key for every surviving paper (skip victims, skip already-correct)
+        # Re-fetch live paper ids (victims are now deleted)
+        live_papers = [r["id"] for r in K.r(d, 'match $p isa scilit-paper, has id $id; fetch {"id": $id};')]
+        swapped, skipped = 0, 0
+        for pid in live_papers:
+            if pid not in newid:
+                # Paper not in original list (shouldn't happen) - skip
+                continue
+            nid = newid[pid]
+            tier, val = basis[pid]
+            if pid == nid:
+                # Already at target id, just ensure identity attrs are set
+                skipped += 1
+            else:
+                # Swap the id @key: delete old, insert new
+                K.w(d, (f'match $p isa scilit-paper, has id $o; $o == "{pid}"; '
+                         f'delete has $o of $p; insert $p has id "{nid}";'))
+                swapped += 1
+            # Set identity attrs if not present (idempotent)
+            if not K._has(d, f'$p isa scilit-paper, has id "{nid}", has scilit-identity-basis $b;'):
+                K.w(d, (f'match $p isa scilit-paper, has id "{nid}"; '
+                         f'insert $p has scilit-identity-basis "{escape_string(tier)}", '
+                         f'has scilit-identity-value "{escape_string(val)}";'))
+        print(f"\nId swap: {swapped} swapped, {skipped} already at target id")
+
+        # 3. Rewrite scilit-reference-key prefixes (old citing-paper id -> new)
+        rk_rows = K.r(d, 'match $p isa scilit-paper, has scilit-reference-key $k; '
+                         'fetch {"id": $p.id, "k": $k};')
+        rk_rewritten = 0
+        for row in rk_rows:
+            k = row["k"]
+            old_prefix = k.split(":")[0]
+            # Only rewrite if the prefix was a paper id that got remapped
+            if old_prefix in newid and newid[old_prefix] != old_prefix:
+                new_prefix = newid[old_prefix]
+                suffix = k.split(":", 1)[1]
+                nk = new_prefix + ":" + suffix
+                pid = row["id"]
+                # Delete old key
+                K.w(d, (f'match $p isa scilit-paper, has id "{pid}", has scilit-reference-key $x; '
+                         f'$x == "{escape_string(k)}"; delete has $x of $p;'))
+                # Insert new key
+                K.w(d, (f'match $p isa scilit-paper, has id "{pid}"; '
+                         f'insert $p has scilit-reference-key "{escape_string(nk)}";'))
+                rk_rewritten += 1
+        print(f"Reference-key prefixes rewritten: {rk_rewritten}")
+
+        print("\nAPPLIED")
+    finally:
+        d.close()
+
+
+if __name__ == "__main__":
+    main(apply="--apply" in sys.argv)

--- a/skills/biomed/scientific-literature/prototypes/reconcile_legacy_fulltext.py
+++ b/skills/biomed/scientific-literature/prototypes/reconcile_legacy_fulltext.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Reconcile scilit-papers whose source PDF is legacy-named (`pdf/artifact-<id>.pdf`,
 reachable only via the paper's existing non-fulltext artifact, not by DOI filename)
-into the unified full-text scheme: symlink the source to `fulltext/<paper-id>/source.pdf`,
-create the deterministic `scilit-fulltext-<paper-hash>-pdf` artifact + alh-representation,
+into the unified full-text scheme: symlink the source to `fulltext/<paper-id>/<artifact-id>.pdf`,
+create the deterministic `scilit-fulltext-<paper-hash>` artifact + alh-representation,
 set acquisition-status=held if missing. Dry-run unless --apply; symlink unless --move."""
 import os, sys, shutil
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -53,8 +53,8 @@ def main(apply=False, move=False):
             print("DRY-RUN. Re-run with --apply."); return
         art=lnk=sym=stat=0
         for pid, src in plan:
-            aid = f"scilit-fulltext-{pid.split('-')[-1]}-pdf"
-            dst_rel = f"fulltext/{pid}/source.pdf"; dst = os.path.join(CACHE, dst_rel)
+            aid = f"scilit-fulltext-{pid.split('-')[-1]}"
+            dst_rel = f"fulltext/{pid}/{aid}.pdf"; dst = os.path.join(CACHE, dst_rel)
             os.makedirs(os.path.dirname(dst), exist_ok=True)
             if not os.path.exists(dst):
                 shutil.move(src, dst); sym += 1

--- a/skills/biomed/scientific-literature/prototypes/reconcile_legacy_fulltext.py
+++ b/skills/biomed/scientific-literature/prototypes/reconcile_legacy_fulltext.py
@@ -4,7 +4,7 @@ reachable only via the paper's existing non-fulltext artifact, not by DOI filena
 into the unified full-text scheme: symlink the source to `fulltext/<paper-id>/source.pdf`,
 create the deterministic `scilit-fulltext-<paper-hash>-pdf` artifact + alh-representation,
 set acquisition-status=held if missing. Dry-run unless --apply; symlink unless --move."""
-import os, sys
+import os, sys, shutil
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, ROOT)
 import kqed as K
@@ -57,7 +57,7 @@ def main(apply=False, move=False):
             dst_rel = f"fulltext/{pid}/source.pdf"; dst = os.path.join(CACHE, dst_rel)
             os.makedirs(os.path.dirname(dst), exist_ok=True)
             if not os.path.exists(dst):
-                (os.rename if move else os.symlink)(src, dst); sym += 1
+                shutil.move(src, dst); sym += 1
             if not K._exists(d, aid):
                 ts = get_timestamp()
                 K.w(d, f'insert $a isa alh-artifact, has id "{aid}", has cache-path "{escape_string(dst_rel)}", '

--- a/skills/biomed/scientific-literature/prototypes/reconcile_legacy_fulltext.py
+++ b/skills/biomed/scientific-literature/prototypes/reconcile_legacy_fulltext.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Reconcile scilit-papers whose source PDF is legacy-named (`pdf/artifact-<id>.pdf`,
+reachable only via the paper's existing non-fulltext artifact, not by DOI filename)
+into the unified full-text scheme: symlink the source to `fulltext/<paper-id>/source.pdf`,
+create the deterministic `scilit-fulltext-<paper-hash>-pdf` artifact + alh-representation,
+set acquisition-status=held if missing. Dry-run unless --apply; symlink unless --move."""
+import os, sys
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+import kqed as K
+from kqed import escape_string, get_timestamp
+CACHE = os.path.expanduser("~/.alhazen/cache")
+
+def source_for(aid, cache_path):
+    """Candidate source PDFs for a legacy artifact, first existing wins."""
+    cands = [os.path.join(CACHE, "pdf", f"{aid}.pdf")]               # pdf/artifact-<id>.pdf
+    if cache_path:
+        if cache_path.lower().endswith(".pdf"):
+            cands.append(os.path.join(CACHE, cache_path))            # cache-path already a pdf
+        if cache_path.startswith("text/") and cache_path.endswith(".txt"):
+            cands.append(os.path.join(CACHE, "pdf", os.path.basename(cache_path)[:-4] + ".pdf"))
+    for c in cands:
+        if os.path.exists(c):
+            return c
+    return None
+
+def main(apply=False, move=False):
+    d = K.get_driver()
+    try:
+        # papers that already have a NEW fulltext pdf artifact -> skip
+        done = set(r["id"] for r in K.r(d,
+            'match $p isa scilit-paper, has id $id; $a isa alh-artifact, has scilit-fulltext-kind "pdf"; '
+            '(alh-artifact:$a, referent:$p) isa alh-representation; fetch {"id":$id};'))
+        # papers with ANY linked artifact + that artifact's id/cache-path
+        cand = {}
+        for r in K.r(d, 'match $p isa scilit-paper, has id $pid; '
+                        '$a isa alh-artifact, has id $aid, has cache-path $cp; '
+                        '(alh-artifact:$a, referent:$p) isa alh-representation; '
+                        'fetch {"pid":$pid,"aid":$aid,"cp":$cp};'):
+            if r["pid"] in done: continue
+            if r["aid"].startswith("scilit-fulltext-"): continue
+            cand.setdefault(r["pid"], []).append((r["aid"], r["cp"]))
+        plan = []
+        for pid, arts in cand.items():
+            src = None
+            for aid, cp in arts:
+                src = source_for(aid, cp)
+                if src: break
+            if src:
+                plan.append((pid, src))
+        print(f"papers needing legacy reconcile={len(cand)} | source PDF resolved={len(plan)} | unresolved={len(cand)-len(plan)}")
+        if not apply:
+            print("DRY-RUN. Re-run with --apply."); return
+        art=lnk=sym=stat=0
+        for pid, src in plan:
+            aid = f"scilit-fulltext-{pid.split('-')[-1]}-pdf"
+            dst_rel = f"fulltext/{pid}/source.pdf"; dst = os.path.join(CACHE, dst_rel)
+            os.makedirs(os.path.dirname(dst), exist_ok=True)
+            if not os.path.exists(dst):
+                (os.rename if move else os.symlink)(src, dst); sym += 1
+            if not K._exists(d, aid):
+                ts = get_timestamp()
+                K.w(d, f'insert $a isa alh-artifact, has id "{aid}", has cache-path "{escape_string(dst_rel)}", '
+                       f'has scilit-fulltext-kind "pdf", has format "application/pdf", has created-at {ts};'); art += 1
+            if not K._has(d, f'$p isa scilit-paper, has id "{pid}"; $a isa alh-artifact, has id "{aid}"; '
+                            f'$r isa alh-representation, links (alh-artifact:$a, referent:$p);'):
+                K.w(d, f'match $a isa alh-artifact, has id "{aid}"; $p isa scilit-paper, has id "{pid}"; '
+                       f'insert (alh-artifact:$a, referent:$p) isa alh-representation;'); lnk += 1
+            if not K._has(d, f'$p isa scilit-paper, has id "{pid}", has scilit-acquisition-status $s;'):
+                K.w(d, f'match $p isa scilit-paper, has id "{pid}"; insert $p has scilit-acquisition-status "held";'); stat += 1
+        print(f"APPLIED: artifacts={art} links={lnk} symlinks={sym} status-set={stat}")
+    finally:
+        d.close()
+
+if __name__ == "__main__":
+    main(apply="--apply" in sys.argv, move="--move" in sys.argv)

--- a/skills/biomed/scientific-literature/prototypes/reconcile_papers_fulltext.py
+++ b/skills/biomed/scientific-literature/prototypes/reconcile_papers_fulltext.py
@@ -6,7 +6,7 @@ scheme as every other scilit investigation: symlink the source to
 artifact (kind=pdf) linked via alh-representation, and set acquisition-status=held.
 
 Dry-run unless --apply; symlink unless --move."""
-import os, sys, glob
+import os, sys, glob, shutil
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, ROOT)
 import kqed as K
@@ -47,7 +47,7 @@ def main(apply=False, move=False):
             dst = os.path.join(CACHE, dst_rel)
             os.makedirs(os.path.dirname(dst), exist_ok=True)
             if not os.path.exists(dst):
-                (os.rename if move else os.symlink)(src, dst); sym += 1
+                shutil.move(src, dst); sym += 1
             if not K._exists(d, aid):
                 ts = get_timestamp()
                 K.w(d, f'insert $a isa alh-artifact, has id "{aid}", has cache-path "{escape_string(dst_rel)}", '

--- a/skills/biomed/scientific-literature/prototypes/reconcile_papers_fulltext.py
+++ b/skills/biomed/scientific-literature/prototypes/reconcile_papers_fulltext.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Reconcile scilit-papers whose source PDF lives in the `papers/` download workspace
+(e.g. CAIS-2026, DOI-structured `papers/<prefix>/<suffix>.pdf`) into the SAME full-text
+scheme as every other scilit investigation: symlink the source to
+`fulltext/<paper-id>/source.pdf`, create the deterministic `scilit-fulltext-<paper-hash>-pdf`
+artifact (kind=pdf) linked via alh-representation, and set acquisition-status=held.
+
+Dry-run unless --apply; symlink unless --move."""
+import os, sys, glob
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+import kqed as K
+from kqed import escape_string, get_timestamp
+CACHE = os.path.expanduser("~/.alhazen/cache")
+
+def papers_dir_index():
+    """DOI (lower) -> source path, for files under cache/papers/<prefix>/<suffix>.pdf"""
+    idx = {}
+    for f in glob.glob(os.path.join(CACHE, "papers", "**", "*.pdf"), recursive=True):
+        prefix = os.path.basename(os.path.dirname(f))
+        doi = f"{prefix}/{os.path.basename(f)[:-4]}".lower()
+        idx[doi] = f
+    return idx
+
+def main(apply=False, move=False):
+    d = K.get_driver()
+    try:
+        src_by_doi = papers_dir_index()
+        rows = K.r(d, 'match $p isa scilit-paper, has id $id, has scilit-doi $x; fetch {"id":$id,"x":$x};')
+        plan = []
+        for r in rows:
+            pid, doi = r["id"], (r["x"] or "").strip().lower()
+            src = src_by_doi.get(doi)
+            if not src:
+                continue
+            aid = f"scilit-fulltext-{pid.split('-')[-1]}-pdf"
+            linked = K._has(d, f'$p isa scilit-paper, has id "{pid}"; $a isa alh-artifact, has id "{aid}"; '
+                              f'$r isa alh-representation, links (alh-artifact: $a, referent: $p);')
+            has_status = K._has(d, f'$p isa scilit-paper, has id "{pid}", has scilit-acquisition-status $s;')
+            plan.append((pid, doi, aid, src, f"fulltext/{pid}/source.pdf", linked, has_status))
+        print(f"papers/-sourced scilit-papers={len(plan)} | already-linked={sum(1 for x in plan if x[5])} "
+              f"| to-link={sum(1 for x in plan if not x[5])} | missing-status={sum(1 for x in plan if not x[6])}")
+        if not apply:
+            print("DRY-RUN. Re-run with --apply."); return
+        art=lnk=sym=stat=0
+        for pid, doi, aid, src, dst_rel, linked, has_status in plan:
+            dst = os.path.join(CACHE, dst_rel)
+            os.makedirs(os.path.dirname(dst), exist_ok=True)
+            if not os.path.exists(dst):
+                (os.rename if move else os.symlink)(src, dst); sym += 1
+            if not K._exists(d, aid):
+                ts = get_timestamp()
+                K.w(d, f'insert $a isa alh-artifact, has id "{aid}", has cache-path "{escape_string(dst_rel)}", '
+                       f'has scilit-fulltext-kind "pdf", has format "application/pdf", has created-at {ts};'); art += 1
+            if not linked:
+                K.w(d, f'match $a isa alh-artifact, has id "{aid}"; $p isa scilit-paper, has id "{pid}"; '
+                       f'insert (alh-artifact: $a, referent: $p) isa alh-representation;'); lnk += 1
+            if not has_status:
+                K.w(d, f'match $p isa scilit-paper, has id "{pid}"; insert $p has scilit-acquisition-status "held";'); stat += 1
+        print(f"APPLIED: artifacts={art} links={lnk} symlinks={sym} status-set={stat}")
+    finally:
+        d.close()
+
+if __name__ == "__main__":
+    main(apply="--apply" in sys.argv, move="--move" in sys.argv)

--- a/skills/biomed/scientific-literature/prototypes/reconcile_papers_fulltext.py
+++ b/skills/biomed/scientific-literature/prototypes/reconcile_papers_fulltext.py
@@ -2,7 +2,7 @@
 """Reconcile scilit-papers whose source PDF lives in the `papers/` download workspace
 (e.g. CAIS-2026, DOI-structured `papers/<prefix>/<suffix>.pdf`) into the SAME full-text
 scheme as every other scilit investigation: symlink the source to
-`fulltext/<paper-id>/source.pdf`, create the deterministic `scilit-fulltext-<paper-hash>-pdf`
+`fulltext/<paper-id>/<artifact-id>.pdf`, create the deterministic `scilit-fulltext-<paper-hash>`
 artifact (kind=pdf) linked via alh-representation, and set acquisition-status=held.
 
 Dry-run unless --apply; symlink unless --move."""
@@ -33,11 +33,11 @@ def main(apply=False, move=False):
             src = src_by_doi.get(doi)
             if not src:
                 continue
-            aid = f"scilit-fulltext-{pid.split('-')[-1]}-pdf"
+            aid = f"scilit-fulltext-{pid.split('-')[-1]}"
             linked = K._has(d, f'$p isa scilit-paper, has id "{pid}"; $a isa alh-artifact, has id "{aid}"; '
                               f'$r isa alh-representation, links (alh-artifact: $a, referent: $p);')
             has_status = K._has(d, f'$p isa scilit-paper, has id "{pid}", has scilit-acquisition-status $s;')
-            plan.append((pid, doi, aid, src, f"fulltext/{pid}/source.pdf", linked, has_status))
+            plan.append((pid, doi, aid, src, f"fulltext/{pid}/{aid}.pdf", linked, has_status))
         print(f"papers/-sourced scilit-papers={len(plan)} | already-linked={sum(1 for x in plan if x[5])} "
               f"| to-link={sum(1 for x in plan if not x[5])} | missing-status={sum(1 for x in plan if not x[6])}")
         if not apply:

--- a/skills/biomed/scientific-literature/prototypes/reconcile_remaining_fulltext.py
+++ b/skills/biomed/scientific-literature/prototypes/reconcile_remaining_fulltext.py
@@ -3,7 +3,7 @@
 locate a source PDF under alternate cache/pdf naming (arXiv `arxiv-<id>*.pdf`, or a fuzzy
 normalized-DOI prefix that tolerates malformed suffixes). Link found sources into the
 fulltext scheme; mark genuinely-sourceless papers `needed`. Dry-run unless --apply."""
-import os, sys, glob
+import os, sys, glob, shutil
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, ROOT)
 import kqed as K
@@ -41,7 +41,7 @@ def main(apply=False, move=False):
             aid = f"scilit-fulltext-{pid.split('-')[-1]}-pdf"
             dst_rel = f"fulltext/{pid}/source.pdf"; dst = os.path.join(CACHE, dst_rel)
             os.makedirs(os.path.dirname(dst), exist_ok=True)
-            if not os.path.exists(dst): (os.rename if move else os.symlink)(src, dst); sym+=1
+            if not os.path.exists(dst): shutil.move(src, dst); sym+=1
             if not K._exists(d, aid):
                 ts=get_timestamp()
                 K.w(d, f'insert $a isa alh-artifact, has id "{aid}", has cache-path "{escape_string(dst_rel)}", '

--- a/skills/biomed/scientific-literature/prototypes/reconcile_remaining_fulltext.py
+++ b/skills/biomed/scientific-literature/prototypes/reconcile_remaining_fulltext.py
@@ -38,8 +38,8 @@ def main(apply=False, move=False):
             print("DRY-RUN."); return
         art=lnk=sym=stat=mark=0
         for pid, doi, src in recl:
-            aid = f"scilit-fulltext-{pid.split('-')[-1]}-pdf"
-            dst_rel = f"fulltext/{pid}/source.pdf"; dst = os.path.join(CACHE, dst_rel)
+            aid = f"scilit-fulltext-{pid.split('-')[-1]}"
+            dst_rel = f"fulltext/{pid}/{aid}.pdf"; dst = os.path.join(CACHE, dst_rel)
             os.makedirs(os.path.dirname(dst), exist_ok=True)
             if not os.path.exists(dst): shutil.move(src, dst); sym+=1
             if not K._exists(d, aid):

--- a/skills/biomed/scientific-literature/prototypes/reconcile_remaining_fulltext.py
+++ b/skills/biomed/scientific-literature/prototypes/reconcile_remaining_fulltext.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Final tail: for DOI papers still without a full-text artifact and not marked 'needed',
+locate a source PDF under alternate cache/pdf naming (arXiv `arxiv-<id>*.pdf`, or a fuzzy
+normalized-DOI prefix that tolerates malformed suffixes). Link found sources into the
+fulltext scheme; mark genuinely-sourceless papers `needed`. Dry-run unless --apply."""
+import os, sys, glob
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+import kqed as K
+from kqed import escape_string, get_timestamp
+CACHE = os.path.expanduser("~/.alhazen/cache")
+PDF = os.path.join(CACHE, "pdf")
+
+def find_source(doi):
+    if "arxiv." in doi:
+        aid = doi.split("arxiv.")[-1]
+        for pat in (f"arxiv-{aid}*.pdf", f"arxiv-{aid.replace('.','_')}*.pdf"):
+            h = glob.glob(os.path.join(PDF, pat))
+            if h: return h[0]
+    base = doi.replace("/", "_")
+    h = sorted(glob.glob(os.path.join(PDF, base + "*.pdf")))
+    return h[0] if h else None
+
+def main(apply=False, move=False):
+    d = K.get_driver()
+    try:
+        rows = K.r(d, 'match $p isa scilit-paper, has id $id, has scilit-doi $x; '
+                      'not {$a isa alh-artifact, has scilit-fulltext-kind "pdf"; (alh-artifact:$a, referent:$p) isa alh-representation;}; '
+                      'not {$p has scilit-acquisition-status "needed";}; fetch {"id":$id,"x":$x};')
+        recl, needed = [], []
+        for r in rows:
+            pid, doi = r["id"], (r["x"] or "").strip().lower()
+            src = find_source(doi)
+            (recl if src else needed).append((pid, doi, src))
+        print(f"tail={len(rows)} | reclaimable(source found)={len(recl)} | mark-needed(no source)={len(needed)}")
+        if not apply:
+            for pid, doi, src in recl: print("  RECLAIM", doi, "->", os.path.basename(src))
+            print("DRY-RUN."); return
+        art=lnk=sym=stat=mark=0
+        for pid, doi, src in recl:
+            aid = f"scilit-fulltext-{pid.split('-')[-1]}-pdf"
+            dst_rel = f"fulltext/{pid}/source.pdf"; dst = os.path.join(CACHE, dst_rel)
+            os.makedirs(os.path.dirname(dst), exist_ok=True)
+            if not os.path.exists(dst): (os.rename if move else os.symlink)(src, dst); sym+=1
+            if not K._exists(d, aid):
+                ts=get_timestamp()
+                K.w(d, f'insert $a isa alh-artifact, has id "{aid}", has cache-path "{escape_string(dst_rel)}", '
+                       f'has scilit-fulltext-kind "pdf", has format "application/pdf", has created-at {ts};'); art+=1
+            if not K._has(d, f'$p isa scilit-paper, has id "{pid}"; $a isa alh-artifact, has id "{aid}"; '
+                            f'$r isa alh-representation, links (alh-artifact:$a, referent:$p);'):
+                K.w(d, f'match $a isa alh-artifact, has id "{aid}"; $p isa scilit-paper, has id "{pid}"; '
+                       f'insert (alh-artifact:$a, referent:$p) isa alh-representation;'); lnk+=1
+            if not K._has(d, f'$p isa scilit-paper, has id "{pid}", has scilit-acquisition-status $s;'):
+                K.w(d, f'match $p isa scilit-paper, has id "{pid}"; insert $p has scilit-acquisition-status "held";'); stat+=1
+        for pid, doi, src in needed:
+            if not K._has(d, f'$p isa scilit-paper, has id "{pid}", has scilit-acquisition-status $s;'):
+                K.w(d, f'match $p isa scilit-paper, has id "{pid}"; insert $p has scilit-acquisition-status "needed";'); mark+=1
+        print(f"APPLIED: reclaimed artifacts={art} links={lnk} symlinks={sym} held={stat} | marked-needed={mark}")
+    finally:
+        d.close()
+
+if __name__ == "__main__":
+    main(apply="--apply" in sys.argv, move="--move" in sys.argv)

--- a/skills/biomed/scientific-literature/prototypes/rename_fulltext_artifact_files.py
+++ b/skills/biomed/scientific-literature/prototypes/rename_fulltext_artifact_files.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Name full-text cache files by their artifact id. For each pdf full-text artifact
+(`scilit-fulltext-<hash>-pdf` with cache-path `fulltext/<paper-id>/source.pdf`):
+  - re-key the artifact id to the kind-less `scilit-fulltext-<hash>` (one artifact / paper;
+    the .pdf and future .txt renditions share this id-base, differing only by suffix),
+  - rename the file `source.pdf` -> `<new-id>.pdf` (move within the same dir),
+  - update the cache-path file xref,
+  - complete the file xref: backfill content-hash / file-size / mime-type where absent.
+Relations bind to the entity, so the id @key swap preserves alh-representation/fragmentation.
+Dry-run unless --apply."""
+import os, sys, hashlib
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+import kqed as K
+from kqed import escape_string
+CACHE = os.path.expanduser("~/.alhazen/cache")
+
+def main(apply=False):
+    d = K.get_driver()
+    try:
+        rows = K.r(d, 'match $a isa alh-artifact, has scilit-fulltext-kind "pdf", has id $id, has cache-path $cp; '
+                      'fetch {"id":$id,"cp":$cp};')
+        plan, skip, collide = [], 0, []
+        for r in rows:
+            old_aid, old_rel = r["id"], r["cp"]
+            if not old_aid.endswith("-pdf"):
+                skip += 1; continue                       # already kind-less / not a target
+            new_aid = old_aid[:-4]                         # strip trailing "-pdf"
+            parts = old_rel.split("/")                     # fulltext/<paper-id>/source.pdf
+            if len(parts) < 3 or parts[0] != "fulltext":
+                skip += 1; continue
+            paper_id = parts[1]
+            new_rel = f"fulltext/{paper_id}/{new_aid}.pdf"
+            if K._exists(d, new_aid):                      # id collision guard
+                collide.append((old_aid, new_aid)); continue
+            plan.append((old_aid, new_aid, old_rel, new_rel))
+        print(f"pdf fulltext artifacts={len(rows)} | to-rename={len(plan)} | skip(non-target)={skip} | COLLISIONS={len(collide)}")
+        for o,n,_,_ in plan[:6]: print(f"   {o} -> {n}")
+        if collide: print("   !! collisions:", collide[:5])
+        if not apply:
+            print("DRY-RUN. Re-run with --apply."); return
+        moved=rekey=cp=meta=0
+        for old_aid, new_aid, old_rel, new_rel in plan:
+            old_f, new_f = os.path.join(CACHE, old_rel), os.path.join(CACHE, new_rel)
+            if os.path.exists(old_f) and not os.path.exists(new_f):
+                os.rename(old_f, new_f); moved += 1        # same dir => rename
+            # re-key the artifact id (relations survive)
+            K.w(d, f'match $a isa alh-artifact, has id $o; $o == "{escape_string(old_aid)}"; '
+                   f'delete has $o of $a; insert $a has id "{escape_string(new_aid)}";'); rekey += 1
+            # update cache-path file xref
+            K.w(d, f'match $a isa alh-artifact, has id "{escape_string(new_aid)}", has cache-path $v; delete has $v of $a;')
+            K.w(d, f'match $a isa alh-artifact, has id "{escape_string(new_aid)}"; insert $a has cache-path "{escape_string(new_rel)}";'); cp += 1
+            # complete the file xref: content-hash / file-size / mime-type (only where absent)
+            if os.path.exists(new_f):
+                b = open(new_f, "rb").read()
+                if not K._has(d, f'$a isa alh-artifact, has id "{escape_string(new_aid)}", has content-hash $h;'):
+                    K.w(d, f'match $a isa alh-artifact, has id "{escape_string(new_aid)}"; insert $a has content-hash "{hashlib.sha256(b).hexdigest()}";')
+                if not K._has(d, f'$a isa alh-artifact, has id "{escape_string(new_aid)}", has file-size $s;'):
+                    K.w(d, f'match $a isa alh-artifact, has id "{escape_string(new_aid)}"; insert $a has file-size {len(b)};')
+                if not K._has(d, f'$a isa alh-artifact, has id "{escape_string(new_aid)}", has mime-type $m;'):
+                    K.w(d, f'match $a isa alh-artifact, has id "{escape_string(new_aid)}"; insert $a has mime-type "application/pdf";')
+                meta += 1
+        print(f"APPLIED: files-moved={moved} ids-rekeyed={rekey} cache-paths={cp} xref-completed={meta}")
+    finally:
+        d.close()
+
+if __name__ == "__main__":
+    main(apply="--apply" in sys.argv)

--- a/skills/biomed/scientific-literature/prototypes/seed_sirt3_kqed.py
+++ b/skills/biomed/scientific-literature/prototypes/seed_sirt3_kqed.py
@@ -199,14 +199,14 @@ def seed():
             K.add_addresses(d, note, g)
 
         # ---- 4d. hinges (claim -> existing KC stub paper; CFC term) ----
-        stubs = {nm: K.find_or_make_stub_paper(d, nm, pid=f"kqed-stub-{i}")
-                 for i, nm in enumerate(["Guarente 2007 (sirtuins extend lifespan)",
+        stubs = {nm: K.find_or_make_stub_paper(d, nm)
+                 for nm in ["Guarente 2007 (sirtuins extend lifespan)",
                                          "Kanfi 2012 (SIRT6 OE extends lifespan)",
                                          "Qiu 2010 (SIRT3-SOD2 deacetylation)",
                                          "Ito 2006 (ROS limits HSC lifespan)",
                                          "Banerjee 2012 (sirtuin lifespan controversy)",
                                          "Balaban 2005 (passive mitochondrial damage view)",
-                                         "Kiel 2005 (SLAM HSC markers)"])}
+                                         "Kiel 2005 (SLAM HSC markers)"]}
         HINGES = [(C1, "Guarente 2007 (sirtuins extend lifespan)", "PMot"),
                   (C1, "Kanfi 2012 (SIRT6 OE extends lifespan)", "CoCo-"),
                   (C5, "Qiu 2010 (SIRT3-SOD2 deacetylation)", "PUse"),

--- a/skills/biomed/scientific-literature/pyproject.toml
+++ b/skills/biomed/scientific-literature/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "requests>=2.31.0",
     "pyyaml>=6.0.0",
     "tqdm>=4.0.0",
+    "kreuzberg>=4.0.0",
 ]
 
 [dependency-groups]

--- a/skills/biomed/scientific-literature/schema.tql
+++ b/skills/biomed/scientific-literature/schema.tql
@@ -93,6 +93,11 @@ attribute scilit-impact-summary, value string;
 # Fallback locator when a source/citing paper has no DOI
 attribute scilit-source-url, value string;
 
+# Paper identity attributes (KQED)
+attribute scilit-identity-basis, value string;   # doi | pmid | arxiv | content-hash
+attribute scilit-identity-value, value string;    # the normalized basis key
+attribute scilit-fulltext-kind, value string;     # pdf | text | html | supplement
+
 
 # -----------------------------------------------------------------------------
 # ENTITY TYPES - Scientific Literature Collections
@@ -124,6 +129,8 @@ entity scilit-paper sub alh-domain-thing,
     owns scilit-target-genre,
     owns scilit-reference-key @card(0..),
     owns scilit-citation-load,
+    owns scilit-identity-basis,
+    owns scilit-identity-value,
     plays scilit-supplementary-material:paper,
     plays scilit-dataset-usage:paper-entity;
 
@@ -362,6 +369,10 @@ entity scilit-investigation sub alh-note,
 # record-phase upsert in the CLI.
 entity scilit-investigation-phase sub alh-note,
     owns scilit-phase;
+
+
+# Additive extension: core artifact type owns full-text kind
+alh-artifact owns scilit-fulltext-kind;
 
 
 # -----------------------------------------------------------------------------

--- a/skills/biomed/scientific-literature/schema.tql
+++ b/skills/biomed/scientific-literature/schema.tql
@@ -55,6 +55,13 @@ attribute scilit-note-type, value string;
 attribute scilit-extraction-method, value string;
 attribute scilit-extraction-model, value string;
 
+# --- discourse-source + experience-note attributes (KQED discourse/source layer) ---
+attribute scilit-session-type, value string;     # keynote | workshop | tutorial | talk | panel
+attribute scilit-speaker, value string;
+attribute scilit-affiliation, value string;
+attribute scilit-session-url, value string;
+attribute scilit-experience-event, value string; # the occasion, e.g. "CAIS 2026 keynote"
+
 # Dataset specific
 attribute scilit-dataset-url, value string;
 attribute scilit-dataset-format, value string;
@@ -153,6 +160,18 @@ entity scilit-book sub alh-domain-thing,
 
 # SCILIT-PROTOCOL - A published protocol or methods paper
 entity scilit-protocol sub scilit-paper;
+
+
+# SCILIT-SESSION - a discourse SOURCE (keynote/workshop/tutorial/talk/panel), sibling of
+# scilit-paper. The domain-neutral source for spoken/event content used by meeting surveys.
+# alh-aboutness:subject and alh-collection-membership:member are inherited from alh-domain-thing;
+# the scilit-hinge:hinged-to play is added additively below (scilit-hinge is defined later).
+entity scilit-session sub alh-domain-thing,
+    owns scilit-session-type,
+    owns scilit-speaker @card(0..),
+    owns scilit-affiliation @card(0..),
+    owns scilit-session-url,
+    owns scilit-publication-year;
 
 
 # -----------------------------------------------------------------------------
@@ -259,6 +278,13 @@ entity scilit-critique-note sub alh-analysis-note,
 # SCILIT-METHODOLOGY-NOTE - Notes about methods/protocols
 entity scilit-methodology-note sub alh-sensemaking-note,
     owns scilit-note-type;
+
+
+# SCILIT-EXPERIENCE-NOTE - a first-person anecdote / engagement record (System 1 rhetorical,
+# discourse layer). `about` a source (session/paper) or person via the inherited alh-aboutness:note.
+# Distinct from the KQED epistemic scilit-observation (a measurement-in-context, System 2).
+entity scilit-experience-note sub alh-sensemaking-note,
+    owns scilit-experience-event;
 
 
 # SCILIT-FACETING-NOTE - A re-runnable feature-faceting workflow over one or more scilit corpora.
@@ -453,6 +479,7 @@ entity scilit-claim plays scilit-hinge:hinging-claim,
     plays scilit-hinge:hinged-to,
     plays scilit-addresses:addressing-note;
 entity scilit-paper plays scilit-hinge:hinged-to;
+entity scilit-session plays scilit-hinge:hinged-to;
 entity alh-vocabulary-type plays kefed-licenses:licensing-type,
     plays kefed-licenses:licensed-warrant;
 

--- a/skills/biomed/scientific-literature/scientific_literature.py
+++ b/skills/biomed/scientific-literature/scientific_literature.py
@@ -74,10 +74,10 @@ except ImportError:
     print("Warning: requests not installed. Run: uv add requests", file=sys.stderr)
 
 try:
-    import pdfplumber
-    PDFPLUMBER_AVAILABLE = True
+    import kreuzberg  # noqa: F401  (layout/table-aware full-text extraction)
+    KREUZBERG_AVAILABLE = True
 except ImportError:
-    PDFPLUMBER_AVAILABLE = False
+    KREUZBERG_AVAILABLE = False
 
 # ---------------------------------------------------------------------------
 # Cache utilities (inlined — no external package needed)
@@ -116,20 +116,24 @@ def should_cache(content):
     return len(content) >= _CACHE_THRESHOLD
 
 
-def save_to_cache(artifact_id, content, mime_type):
+def save_to_cache(artifact_id, content, mime_type, subdir=None):
+    """Write a cached file. When `subdir` is given (e.g. "fulltext/<paper-id>"), the file
+    lands at <subdir>/<artifact_id>.<ext> (the per-paper full-text layout); otherwise the
+    legacy by-type layout <type_dir>/<artifact_id>.<ext>."""
     if isinstance(content, str):
         content_bytes = content.encode("utf-8")
     else:
         content_bytes = content
     type_dir, ext = _MIME_TYPE_MAP.get(mime_type, ("other", "bin"))
     cache_dir = _get_cache_dir()
-    type_path = cache_dir / type_dir
-    type_path.mkdir(parents=True, exist_ok=True)
+    rel_dir = subdir if subdir else type_dir
+    base = cache_dir / rel_dir
+    base.mkdir(parents=True, exist_ok=True)
     filename = f"{artifact_id}.{ext}"
-    full_path = type_path / filename
+    full_path = base / filename
     full_path.write_bytes(content_bytes)
     return {
-        "cache_path": f"{type_dir}/{filename}",
+        "cache_path": f"{rel_dir}/{filename}",
         "file_size": len(content_bytes),
         "content_hash": hashlib.sha256(content_bytes).hexdigest(),
         "full_path": str(full_path),
@@ -1019,9 +1023,9 @@ def arxiv_pdf_url(doi: str) -> str | None:
 
 def cmd_fetch_pdf(args):
     """Download a paper PDF, extract full text, save both to disk, store artifact in TypeDB."""
-    if not PDFPLUMBER_AVAILABLE:
+    if not KREUZBERG_AVAILABLE:
         print(json.dumps({"success": False,
-                          "error": "pdfplumber not installed. Run: uv add pdfplumber"}))
+                          "error": "kreuzberg not installed. Run: uv add kreuzberg"}))
         sys.exit(1)
     if not CACHE_AVAILABLE:
         print(json.dumps({"success": False,
@@ -1060,8 +1064,8 @@ def cmd_fetch_pdf(args):
             art = existing[0]
             artifact_id = art.get("id")
             text_cache_path = art.get("cache-path") or ""
-            pdf_cache_path = (text_cache_path.replace("text/", "pdf/").replace(".txt", ".pdf")
-                              if text_cache_path else "")
+            # renditions are siblings sharing the artifact-id base; pdf = swap the suffix
+            pdf_cache_path = text_cache_path.replace(".txt", ".pdf") if text_cache_path else ""
             print(json.dumps({
                 "success": True,
                 "paper_id": paper_id,
@@ -1096,42 +1100,47 @@ def cmd_fetch_pdf(args):
                           "error": "Response is not a PDF (bad URL or access denied)"}))
         sys.exit(1)
 
-    # Generate single artifact_id used as stem for BOTH cache files
-    artifact_id = generate_id("artifact")
+    # Deterministic full-text artifact id; both renditions live in fulltext/<paper-id>/,
+    # named by the artifact id and sharing the base (suffix = format).
+    artifact_id = f"scilit-fulltext-{paper_id.split('-')[-1]}"
+    subdir = f"fulltext/{paper_id}"
 
-    # Save PDF binary  ->  pdf/{artifact_id}.pdf
-    pdf_cache = save_to_cache(artifact_id, pdf_bytes, "application/pdf")
+    # Save PDF source  ->  fulltext/<paper-id>/<artifact-id>.pdf
+    pdf_cache = save_to_cache(artifact_id, pdf_bytes, "application/pdf", subdir=subdir)
 
-    # Extract full text - NO character cap
+    # Extract full text with kreuzberg (layout/table-aware)  ->  fulltext/<paper-id>/<artifact-id>.txt
     print(f"Extracting text ({len(pdf_bytes):,} bytes, {pdf_cache['full_path']}) ...",
           file=sys.stderr)
-    import io as _io
-    all_pages = []
-    with pdfplumber.open(_io.BytesIO(pdf_bytes)) as pdf:
-        page_count = len(pdf.pages)
-        for page in pdf.pages:
-            page_text = page.extract_text() or ""
-            if page_text.strip():
-                all_pages.append(page_text)
-
-    full_text = "\n\n".join(all_pages)
-    print(f"Extracted {len(full_text):,} chars from {page_count} pages.", file=sys.stderr)
-
-    # Save extracted text  ->  text/{artifact_id}.txt
-    text_cache = save_to_cache(artifact_id, full_text, "text/plain")
+    from kreuzberg import extract_file_sync
+    _res = extract_file_sync(pdf_cache["full_path"])
+    full_text = _res.content or ""
+    try:
+        page_count = int((getattr(_res, "metadata", None) or {}).get("page_count") or 0)
+    except Exception:
+        page_count = 0
+    print(f"Extracted {len(full_text):,} chars.", file=sys.stderr)
+    text_cache = save_to_cache(artifact_id, full_text, "text/plain", subdir=subdir)
 
     timestamp = get_timestamp()
 
-    # Insert scilit-pdf-fulltext artifact into TypeDB
-    name_esc = escape_string(f"{paper_name} [PDF text]")
+    # Upsert the scilit-pdf-fulltext artifact (deterministic id). cache-path -> the .txt
+    # rendition (indexable); the .pdf is the sibling by suffix.
+    name_esc = escape_string(f"{paper_name} [full text]")
     with get_driver() as driver:
         with driver.transaction(TYPEDB_DATABASE, TransactionType.WRITE) as tx:
+            # idempotent (handles --force re-download): drop any prior artifact at this id
+            tx.query(f'match $a isa alh-artifact, has id "{artifact_id}"; '
+                     f'$r isa alh-fragmentation, links (whole: $a); delete $r;').resolve()
+            tx.query(f'match $a isa alh-artifact, has id "{artifact_id}"; '
+                     f'$r isa alh-representation, links (alh-artifact: $a); delete $r;').resolve()
+            tx.query(f'match $a isa alh-artifact, has id "{artifact_id}"; delete $a;').resolve()
             tx.query(
                 f'insert $a isa scilit-pdf-fulltext, '
                 f'has id "{artifact_id}", '
                 f'has name "{name_esc}", '
                 f'has source-uri "{escape_string(pdf_url)}", '
                 f'has cache-path "{escape_string(text_cache["cache_path"])}", '
+                f'has scilit-fulltext-kind "pdf", '
                 f'has mime-type "text/plain", '
                 f'has file-size {text_cache["file_size"]}, '
                 f'has content-hash "{text_cache["content_hash"]}", '
@@ -1140,13 +1149,19 @@ def cmd_fetch_pdf(args):
             ).resolve()
             tx.commit()
 
-        # Link artifact -> paper via representation
+        # Link artifact -> paper via representation + mark the paper held
         with driver.transaction(TYPEDB_DATABASE, TransactionType.WRITE) as tx:
             tx.query(
                 f'match $p isa scilit-paper, has id "{escape_string(paper_id)}"; '
                 f'$a isa scilit-pdf-fulltext, has id "{artifact_id}"; '
                 f'insert (alh-artifact: $a, referent: $p) isa alh-representation;'
             ).resolve()
+            held = list(tx.query(
+                f'match $p isa scilit-paper, has id "{escape_string(paper_id)}", '
+                f'has scilit-acquisition-status $s; fetch {{ "s": $s }};').resolve())
+            if not held:
+                tx.query(f'match $p isa scilit-paper, has id "{escape_string(paper_id)}"; '
+                         f'insert $p has scilit-acquisition-status "held";').resolve()
             tx.commit()
 
     print(json.dumps({

--- a/skills/biomed/scientific-literature/tests/test_paper_identity.py
+++ b/skills/biomed/scientific-literature/tests/test_paper_identity.py
@@ -1,0 +1,28 @@
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from paper_identity import canon_doi, content_basis, paper_identity
+
+def test_canon_doi_strips_prefixes_and_lowercases():
+    assert canon_doi("https://doi.org/10.1016/J.Cell.2022.11.001") == "10.1016/j.cell.2022.11.001"
+    assert canon_doi("doi:10.1038/NATURE19768") == "10.1038/nature19768"
+    assert canon_doi("  10.1111/acel.13524.  ") == "10.1111/acel.13524"
+    assert canon_doi(None) == "" and canon_doi("") == ""
+
+def test_identity_is_deterministic_and_doi_first():
+    pid1, tier, val = paper_identity({"doi": "10.1016/j.cell.2022.11.001", "pmid": "36599349"})
+    pid2, _, _ = paper_identity({"doi": "HTTPS://doi.org/10.1016/J.CELL.2022.11.001"})
+    assert pid1 == pid2                      # normalization → same id
+    assert tier == "doi" and val == "10.1016/j.cell.2022.11.001"
+    assert pid1.startswith("scilit-paper-") and len(pid1) == len("scilit-paper-") + 12
+
+def test_fallback_chain_pmid_then_arxiv_then_content():
+    assert paper_identity({"pmid": "16904174"})[1] == "pmid"
+    assert paper_identity({"arxiv": "2301.00001"})[1] == "arxiv"
+    pid, tier, val = paper_identity({"title": "The Hallmarks of Aging", "first_author": "Lopez-Otin", "year": 2023})
+    assert tier == "content-hash" and val == "the hallmarks of aging|lopez-otin|2023"
+
+def test_tiers_do_not_collide():
+    # a DOI string and a PMID string that look alike must not produce the same id
+    a, _, _ = paper_identity({"doi": "12345"})
+    b, _, _ = paper_identity({"pmid": "12345"})
+    assert a != b

--- a/skills/biomed/scientific-literature/tests/test_upsert_paper.py
+++ b/skills/biomed/scientific-literature/tests/test_upsert_paper.py
@@ -1,0 +1,21 @@
+import os, sys
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+import kqed as K
+from paper_identity import paper_identity
+
+def test_upsert_is_idempotent_and_deterministic():
+    d = K.get_driver()
+    try:
+        meta = {"doi": "10.9999/itest.paper.identity", "name": "Test Paper", "pmid": "99999999"}
+        expected_id, _, _ = paper_identity(meta)
+        K.w(d, f'match $p isa scilit-paper, has id "{expected_id}"; delete $p;') if K._exists(d, expected_id) else None
+        id1 = K.upsert_paper(d, meta)
+        id2 = K.upsert_paper(d, meta)            # second call must not create a duplicate
+        assert id1 == id2 == expected_id
+        count = sum(1 for _ in K.r(d, f'match $p isa scilit-paper, has id "{expected_id}"; select $p;'))
+        assert count == 1
+        assert K._has(d, f'$p isa scilit-paper, has id "{expected_id}", has scilit-identity-basis "doi";')
+    finally:
+        K.w(d, f'match $p isa scilit-paper, has id "{expected_id}"; delete $p;')
+        d.close()

--- a/skills/biomed/scientific-literature/uv.lock
+++ b/skills/biomed/scientific-literature/uv.lock
@@ -7,6 +7,7 @@ name = "alhazen-skill-scientific-literature"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "kreuzberg" },
     { name = "pyyaml" },
     { name = "requests" },
     { name = "tqdm" },
@@ -15,6 +16,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "kreuzberg", specifier = ">=4.0.0" },
     { name = "pyyaml", specifier = ">=6.0.0" },
     { name = "requests", specifier = ">=2.31.0" },
     { name = "tqdm", specifier = ">=4.0.0" },
@@ -106,6 +108,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "kreuzberg"
+version = "4.9.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/6a/5f4f8b72aaa7f2c8ce916e4ee6f405592b97ad8d21f43517ba66ea0a8467/kreuzberg-4.9.9.tar.gz", hash = "sha256:c563e3741277f23f6752abdd912dbb2e99ea727188170d4f498fc1222cdff5b6", size = 2435924, upload-time = "2026-06-05T14:30:48.148Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/ba/e94d075e3f7b2d5ac463f08f6a3ff0b33a82fe32210ae77c31bd71fe16ab/kreuzberg-4.9.9-cp310-abi3-macosx_14_0_arm64.whl", hash = "sha256:f809692d5a6fb24d233a5e3b2da092392f76926d6092e02e8a63562a80fa4453", size = 28532694, upload-time = "2026-06-05T14:30:27.641Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/2a/0bc8e9550ebd951db16d10bc613d33c9cdbba39ced97edb847f9597a55f8/kreuzberg-4.9.9-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:083b7358534920dc77193c4bdf152a0364e235635e8b850359146615dde8f564", size = 33102430, upload-time = "2026-06-05T14:30:31.501Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/f6/469a80742ca49696087f3967d26f866ec9f72aca3589893b65043415c623/kreuzberg-4.9.9-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:ed57c054b62e79fe2ea1c5fedafbf32dd4087ed33ba612ca63e53ae495651781", size = 35330241, upload-time = "2026-06-05T14:30:40.983Z" },
+    { url = "https://files.pythonhosted.org/packages/36/2f/a19dbd7d379911e389b09d3e7226f8b0e6827482d2b96966ab4c72bb3280/kreuzberg-4.9.9-cp310-abi3-win_amd64.whl", hash = "sha256:ff3d29914c3bedb146ea844526b249d5c3129acf55ee1bf92cfcf4b72dca3392", size = 32855579, upload-time = "2026-06-05T14:30:45.262Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Establishes a position-independent, deterministic identity for `scilit-paper` and a single, computable per-paper full-text layout — replacing opaque random ids and the fragile `<citing>:<position>` reference-key scheme. 21 commits across four arcs, all migrations applied to the shared live DB and verified.

## 1. Deterministic paper identity
- `paper_identity()` pure function: `scilit-paper-<12hex>` = `sha256("<tier>:<value>")[:12]`, tier chain DOI → PMID → arXiv → content-hash; tier recorded in `scilit-identity-basis`/`-value` (+ unit tests).
- `kqed.upsert_paper()` routes all paper creation through it — dedup by construction (the duplicate-DOI class of bug cannot recur).
- Migration of the existing corpus: id `@key` swap (preserves relations), dup-DOI merge, `scilit-reference-key` prefix rewrite.
- Citation fix: hinges re-pointed by in-text position, not the Crossref `bibNN` key.

## 2. Full-text artifact identity + reconciliation
- ONE `scilit-pdf-fulltext` artifact per paper, id `scilit-fulltext-<paper-hash>`; renditions `fulltext/<paper-id>/<artifact-id>.{pdf,txt}` named by the artifact id (suffix = format).
- Reconcilers MOVE cached sources (CAIS, legacy artifact-named PDFs, arxiv/fuzzy tail) into `fulltext/<paper-id>/` — never symlink; sourceless references marked `needed`.
- Complete file xref on every artifact: `cache-path` + `content-hash` + `file-size` + `mime-type` + `format`.

## 3. Text consolidation
- `prototypes/consolidate_fulltext_text.py`: each paper's full text becomes the single `scilit-pdf-fulltext` artifact; legacy text merged via id-swap (fragments preserved), pdf-only artifacts re-typed. Idempotent (`--apply` re-run is a safe no-op); dry-run default.

## 4. Live ingestion rewire
- `cmd_fetch_pdf` now writes the deterministic per-paper layout end-to-end; text extraction switched from pdfplumber to **kreuzberg** (layout/table-aware; added as a skill dependency); `cache-path` = the `.txt` rendition, `.pdf` derived as the sibling by suffix.

## Verification
- Unit tests green (5 passed).
- Live DB: 360 `scilit-pdf-fulltext` artifacts, 0 plain `alh-artifact`; relation counts preserved; KQED epigenetics round-trip + fragment grounding still resolve.
- Live `fetch-pdf` test (fresh arxiv paper): correct layout + xref + status `held`, nothing leaks into `cache/pdf|text/`, re-run idempotent.
- SKILL.md documents the layout as the required convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)